### PR TITLE
Feature/issue 89 add version to cli

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [unreleased]
 ### Added
 - [pull-request/79](https://github.com/nasa/ncompare/pull/79): Add option to only display variables and attributes that are different
+- [pull-request/100](https://github.com/nasa/ncompare/pull/100): Add version to cli
 ### Changed
 ### Deprecated
 ### Removed

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ poetry run ncompare <netcdf file #1> <netcdf file #2>
 
 ### Options
 
-- `-h`, `--help`            show this help message and exit
+- `-h`, `--help` : Show this help message and exit.
 - `--file-text` [FILE_PATH]: Text file to write output to.
 - `--file-csv` [FILE_PATH]: Comma-separated values (CSV) file to write output to.
 - `--file-xlsx` [FILE_PATH]: Excel file to write output to.
@@ -69,6 +69,7 @@ poetry run ncompare <netcdf file #1> <netcdf file #2>
 - `-v` (`--comparison_var_name`) [VAR_NAME]: Compare specific values for this variable.
 - `-g` (`--comparison_var_group`) [VAR_GROUP]: Group that contains the `comparison_var_name`.
 - `--column-widths` [WIDTH, WIDTH, WIDTH]: Width, in number of characters, of the three columns in the comparison report
+- `--version` : Show the current version and then exit.
 
 ## How to test ncompare locally
 

--- a/ncompare/console.py
+++ b/ncompare/console.py
@@ -1,10 +1,13 @@
 #!/usr/bin/env python
 """Command line interface for `ncompare` -- to compare the structure of two NetCDF files."""
 import argparse
+import importlib.metadata
 import sys
 import traceback
 
 from ncompare.core import compare
+
+__version__ = importlib.metadata.version('ncompare')
 
 
 def _cli() -> argparse.Namespace:
@@ -53,7 +56,11 @@ def _cli() -> argparse.Namespace:
     )
 
     parser.add_argument(
-        "--version", action="store_true", default=False, help="Show the current version."
+        "--version",
+        action='version',
+        version=f'%(prog)s {__version__}',
+        default=False,
+        help="Show the current version.",
     )
 
     return parser.parse_args()

--- a/ncompare/console.py
+++ b/ncompare/console.py
@@ -52,6 +52,10 @@ def _cli() -> argparse.Namespace:
         help="Width, in number of characters, of the three columns in the comparison report",
     )
 
+    parser.add_argument(
+        "--version", action="store_true", default=False, help="Show the current version."
+    )
+
     return parser.parse_args()
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,11 @@
+import os
+
+
+def test_console_version():
+    exit_status = os.system('ncompare --version')
+    assert exit_status == 0
+
+
+def test_console_help():
+    exit_status = os.system('ncompare --help')
+    assert exit_status == 0


### PR DESCRIPTION
GitHub Issue: #89

### Description

This change adds a `--version` argument to the command line interface (CLI).

### Local test steps

Passed updated test suite, and successfully ran `poetry run ncompare --version` at the command line.

## PR Acceptance Checklist
* [x] Unit tests added/updated and passing.
* [N/A] Integration testing
* [x] `CHANGELOG.md` updated
* [x] Documentation updated (if needed).
