### PR TITLE
remove version from argparser namespace to prevent exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [pull-request/99](https://github.com/nasa/ncompare/pull/99): Improve readme in a few ways (e.g., license, badges)
 ### Deprecated
 ### Removed
+- fixed bug related to extra argument from command line
 ### Fixed
 - Updated out-dated example snippet in README
 ### Security

--- a/ncompare/console.py
+++ b/ncompare/console.py
@@ -70,6 +70,8 @@ def main():
     """Run from the command line."""
     args = _cli()
 
+    delattr(args, 'version')
+
     try:
         compare(**vars(args))
     except Exception:  # pylint: disable=broad-exception-caught


### PR DESCRIPTION
### Description

This change fixes an error that cropped up during the `--version` addition to the CLI.

### Local test steps

Ran ncompare locally at the command line to test two files, ran it with `--version` only, and successfully passed the test suite.

## PR Acceptance Checklist
* [N/A] Unit tests added/updated and passing.
* [N/A] Integration testing
* [x] `CHANGELOG.md` updated
* [N/A] Documentation updated (if needed).
