### PR TITLE
add codecov step to tests workflow

### DIFF
--- a/.github/workflows/pr-rtd-link.yml
+++ b/.github/workflows/pr-rtd-link.yml
@@ -18,4 +18,4 @@ jobs:
     steps:
       - uses: "readthedocs/actions/preview@v1"
         with:
-          project-slug: "earthaccess"
+          project-slug: "ncompare"

--- a/.github/workflows/reusable_run_tests.yml
+++ b/.github/workflows/reusable_run_tests.yml
@@ -41,16 +41,7 @@ jobs:
         run: |
           poetry run pytest --cov=ncompare --cov-report=xml:build/reports/coverage${{ matrix.python-version }}.xml --cov-report=html:build/reports/coverage${{ matrix.python-version }}.html tests/
 
-      - name: Archive code coverage report (xml)
-        if: ${{ always() }}
-        uses: actions/upload-artifact@v4
-        with:
-          name: code coverage report (xml)
-          path: build/reports/coverage.xml
-
-      - name: Archive code coverage report (HTML)
-        if: ${{ always() }}
-        uses: actions/upload-artifact@v4
-        with:
-          name: code coverage report (HTML)
-          path: build/reports/coverage.html
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v3
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - [pull-request/99](https://github.com/nasa/ncompare/pull/99): Improve readme in a few ways (e.g., license, badges)
 - [pull-request/106](https://github.com/nasa/ncompare/pull/106): Use ReadTheDocs instead of GitHub Pages for documentation
+- [pull-request/113](https://github.com/nasa/ncompare/pull/113): Add codecov step to tests workflow
 ### Deprecated
 ### Removed
 - fixed bug related to extra argument from command line


### PR DESCRIPTION
GitHub Issue: #86

### Description

This change adds a step to the GitHub Actions workflows that generates a coverage report using Codecov.

### Local test steps

N/A

### Overview of integration done

Checking the output from the completed workflow, here: <https://app.codecov.io/gh/nasa/ncompare>.

## PR Acceptance Checklist
* [N/A] Unit tests added/updated and passing.
* [x] Integration testing
* [x] `CHANGELOG.md` updated
* [N/A] Documentation updated (if needed).


<!-- readthedocs-preview earthaccess start -->
----
📚 Documentation preview 📚: https://ncompare--113.org.readthedocs.build/en/113/

<!-- readthedocs-preview earthaccess end -->