### PR TITLE
Disable text wrapping to properly show ncompare output in notebook example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [pull-request/113](https://github.com/nasa/ncompare/pull/113): Add codecov step to tests workflow
 - [issue/88](https://github.com/nasa/ncompare/issues/88): Improve test coverage, especially for ncompare/core.py and ncompare/printing.py
 - [issue/92](https://github.com/nasa/ncompare/issues/92): Ensure examples utilize publicly accessible data
+- [pull-request/121](https://github.com/nasa/ncompare/pull/121): Disable text wrapping to properly show ncompare output in notebook example
 - Tweaked wording regarding docstrings in the contributing guide
 ### Deprecated
 ### Removed

--- a/docs/css/styles.css
+++ b/docs/css/styles.css
@@ -3,3 +3,17 @@
 .jupyter-wrapper .jp-OutputArea-output pre {
   white-space: pre !important;
 }
+@media only screen and (min-width: 76.25em) {
+  .md-main__inner {
+    max-width: none;
+  }
+  .md-sidebar--primary {
+    left: 0;
+  }
+  .md-sidebar--secondary {
+    right: 0;
+    margin-left: 0;
+    -webkit-transform: none;
+    transform: none;
+  }
+}

--- a/docs/css/styles.css
+++ b/docs/css/styles.css
@@ -1,2 +1,5 @@
 .details .open {
 }
+.jupyter-wrapper .jp-OutputArea-output pre {
+  white-space: pre;
+}

--- a/docs/css/styles.css
+++ b/docs/css/styles.css
@@ -1,5 +1,5 @@
 .details .open {
 }
 .jupyter-wrapper .jp-OutputArea-output pre {
-  white-space: pre;
+  white-space: pre !important;
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ncompare"
-version = "1.6.0a38"
+version = "1.6.0a39"
 description = "Compare the structure of two NetCDF files at the command line"
 authors = ["Daniel Kaufman <daniel.kaufman@nasa.gov>"]
 readme = "README.md"


### PR DESCRIPTION
GitHub Issue: #120 

### Description

This change enables the Jupyter notebook in ReadTheDocs to show output without wrapping the text.

### Local test steps

N/A

### Overview of integration done

Checked the created docs page.

## PR Acceptance Checklist
* [N/A] Unit tests added/updated and passing.
* [x] Integration testing
* [x] `CHANGELOG.md` updated
* [x] Documentation updated (if needed).


<!-- readthedocs-preview ncompare start -->
----
📚 Documentation preview 📚: https://ncompare--121.org.readthedocs.build/en/121/

<!-- readthedocs-preview ncompare end -->