### PR TITLE
Feature/issue 208 missing group error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Deprecated
 ### Removed
 ### Fixed
+- [Issue #208](https://github.com/nasa/ncompare/issues/208): Fix missing group error
 - [Pull #190](https://github.com/nasa/ncompare/pull/190): codecov upload token error
 - [Pull #199](https://github.com/nasa/ncompare/pull/199): Resolve linting error
 ### Security

--- a/ncompare/core.py
+++ b/ncompare/core.py
@@ -261,7 +261,7 @@ def walk_common_groups_tree(  # type:ignore[misc]
     )
 
     for _, subgroup_a_name, subgroup_b_name in common_elements(
-        top_a.groups if top_a is not None else "", top_b.groups if top_a is not None else ""
+        top_a.groups if top_a is not None else "", top_b.groups if top_b is not None else ""
     ):
         yield from walk_common_groups_tree(
             top_a_name + "/" + subgroup_a_name if subgroup_a_name else "",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -101,3 +101,88 @@ def ds_3dims_3vars_4coords_1group(temp_data_dir):
     f.close()
 
     return filepath
+
+
+@pytest.fixture(scope="session")
+def ds_3dims_3vars_4coords_2groups(temp_data_dir):
+    filepath = temp_data_dir / "test_3dims_3vars_4coords_2groups.nc"
+
+    f = nC.Dataset(filename=filepath, mode="w")
+    grp1 = f.createGroup('Group1')
+    grp2 = f.createGroup('Group2')
+
+    # A root variable
+    f.createVariable('var0', "i2", ())
+
+    # New/modified coordinates in grp1
+    grp1.createDimension('x', 2)
+    grp1.createDimension('step', 3)
+    grp1.createDimension('track', 7)
+
+    # Variables in grp1
+    grp1.createVariable('var1', 'f8', ())
+    #
+    grp1.createVariable('var2', 'f4', ())
+    #
+    grp1.createVariable('step', 'f4', ('step',), fill_value=False)
+    grp1['step'][:] = [-0.9, -1.8, -2.7]
+    #
+    grp1.createVariable('w', 'u1', ('x', 'step'), fill_value=False)
+
+    # New/modified coordinates in grp2
+    grp2.createDimension('x', 2)
+    grp2.createDimension('step', 3)
+    grp2.createDimension('track', 7)
+    grp2.createDimension('level', 4)
+
+    # Variables in grp2
+    grp2.createVariable('var3', 'f8', ('level',), fill_value=False)
+
+    # Wrap up
+    f.close()
+
+    return filepath
+
+
+@pytest.fixture(scope="session")
+def ds_3dims_3vars_4coords_1subgroup(temp_data_dir):
+    filepath = temp_data_dir / "test_3dims_3vars_4coords_1subgroup.nc"
+
+    f = nC.Dataset(filename=filepath, mode="w")
+    grp1 = f.createGroup('Group1')
+    grp2 = f.createGroup('Group2')
+    grp2_subgroup = grp2.createGroup('Group2_subgroup')
+
+    # A root variable
+    f.createVariable('var0', "i2", ())
+
+    # New/modified coordinates in grp1
+    grp1.createDimension('x', 2)
+    grp1.createDimension('step', 3)
+    grp1.createDimension('track', 7)
+
+    # Variables in grp1
+    grp1.createVariable('var1', 'f8', ())
+    #
+    grp1.createVariable('var2', 'f4', ())
+    #
+    grp1.createVariable('step', 'f4', ('step',), fill_value=False)
+    grp1['step'][:] = [-0.9, -1.8, -2.7]
+    #
+    grp1.createVariable('w', 'u1', ('x', 'step'), fill_value=False)
+
+    # New/modified coordinates in grp2
+    grp2.createDimension('step', 3)
+    grp2.createDimension('level', 4)
+
+    # Variables in grp2
+    grp2.createVariable('var3', 'f8', ('step', 'level'), fill_value=False)
+
+    # New/modified coordinates in grp2
+    # Variables in grp2
+    grp2_subgroup.createVariable('var4', 'f8', ('level',), fill_value=False)
+
+    # Wrap up
+    f.close()
+
+    return filepath

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,17 +1,47 @@
+"""
+Tests for the core module.
+
+Note that full comparison tests are performed in both directions, i.e., A -> B and B -> A.
+"""
+
+from contextlib import nullcontext as does_not_raise
+
 import pytest
 import xarray as xr
 
 from ncompare.core import _get_vars, _match_random_value, _print_sample_values, compare
 
 
-def test_dataset_compare_does_not_raise_exception(ds_3dims_2vars_4coords, ds_4dims_3vars_5coords):
-    compare(ds_3dims_2vars_4coords, ds_4dims_3vars_5coords)
+def compare_ab(a, b):
+    with does_not_raise():
+        compare(a, b)
 
 
-def test_dataset_compare_does_not_raise_exception_2(
-    ds_3dims_2vars_4coords, ds_3dims_3vars_4coords_1group
+def compare_ba(a, b):
+    with does_not_raise():
+        compare(b, a)
+
+
+def test_no_error_compare(ds_3dims_2vars_4coords, ds_4dims_3vars_5coords):
+    compare_ab(ds_3dims_2vars_4coords, ds_4dims_3vars_5coords)
+    compare_ba(ds_3dims_2vars_4coords, ds_4dims_3vars_5coords)
+
+
+def test_no_error_compare_0to1group(ds_3dims_2vars_4coords, ds_3dims_3vars_4coords_1group):
+    compare_ab(ds_3dims_2vars_4coords, ds_3dims_3vars_4coords_1group)
+    compare_ba(ds_3dims_2vars_4coords, ds_3dims_3vars_4coords_1group)
+
+
+def test_no_error_compare_1to2groups(ds_3dims_3vars_4coords_1group, ds_3dims_3vars_4coords_2groups):
+    compare_ab(ds_3dims_3vars_4coords_1group, ds_3dims_3vars_4coords_2groups)
+    compare_ba(ds_3dims_3vars_4coords_1group, ds_3dims_3vars_4coords_2groups)
+
+
+def test_no_error_compare_2groupsTo1Subgroup(
+    ds_3dims_3vars_4coords_2groups, ds_3dims_3vars_4coords_1subgroup
 ):
-    compare(ds_3dims_2vars_4coords, ds_3dims_3vars_4coords_1group)
+    compare_ab(ds_3dims_3vars_4coords_2groups, ds_3dims_3vars_4coords_1subgroup)
+    compare_ba(ds_3dims_3vars_4coords_2groups, ds_3dims_3vars_4coords_1subgroup)
 
 
 def test_matching_random_values(
@@ -42,10 +72,10 @@ def test_matching_random_values(
 
 
 def test_print_values_runs_with_no_error(ds_3dims_3vars_4coords_1group, outputter_to_console):
-    _print_sample_values(
-        outputter_to_console, ds_3dims_3vars_4coords_1group, groupname="Group1", varname="step"
-    )
-    assert True
+    with does_not_raise():
+        _print_sample_values(
+            outputter_to_console, ds_3dims_3vars_4coords_1group, groupname="Group1", varname="step"
+        )
 
 
 def test_print_values_to_text_file_runs_with_no_error(


### PR DESCRIPTION
GitHub Issue: #208 

### Description

This resolves an exception that is raised when comparison is done in the direction A -> B and dataset A contains groups that dataset B does not.

### Local test steps

Added unit tests for subgroups, and modified comparison tests so they are performed in both directions, A->B and B->A.

## PR Acceptance Checklist
* [x] Unit tests added/updated and passing.
* [n/a] Integration testing
* [x] `CHANGELOG.md` updated
* [n/a] Documentation updated (if needed).


<!-- readthedocs-preview ncompare start -->
----
📚 Documentation preview 📚: https://ncompare--209.org.readthedocs.build/en/209/

<!-- readthedocs-preview ncompare end -->