### PR TITLE
add gitleaks hook to pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,6 +8,11 @@ default_language_version:
   python: python3.9
 
 repos:
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.21.2
+    hooks:
+      - id: gitleaks
+
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v5.0.0
     hooks:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add pre-commit autoupdating ([#cde1ae4](https://github.com/nasa/ncompare/pull/260/commits/cde1ae4d7ae8b1d9cf07d4af012e8f97b010238d)) ([**@danielfromearth**](https://github.com/danielfromearth))
+- Add gitleaks to pre-commit ([#261](https://github.com/nasa/ncompare/pull/261)) ([**@danielfromearth**](https://github.com/danielfromearth))
 
 ### Removed
 


### PR DESCRIPTION
GitHub Issue: #112 

### Description

Add gitleaks to the pre-commit hooks.

## PR Acceptance Checklist
* [ ] Unit tests added/updated and passing.
* [ ] Integration testing
* [x] `CHANGELOG.md` updated
* [ ] Documentation updated (if needed).


<!-- readthedocs-preview ncompare start -->
----
📚 Documentation preview 📚: https://ncompare--261.org.readthedocs.build/en/261/

<!-- readthedocs-preview ncompare end -->