### PR TITLE
catch "unsupported datatype" exception from netCDF library when acces…

### DIFF
--- a/ncompare/core.py
+++ b/ncompare/core.py
@@ -568,7 +568,15 @@ def _var_properties(group: Union[netCDF4.Dataset, netCDF4.Group], varname: str) 
         v_dtype = str(the_variable.dtype)
         v_shape = str(the_variable.shape).strip()
         v_chunking = str(the_variable.chunking()).strip()
-        v_attributes = {name: getattr(the_variable, name) for name in the_variable.ncattrs()}
+
+        v_attributes = {}
+        for name in the_variable.ncattrs():
+            try:
+                v_attributes[name] = the_variable.getncattr(name)
+            except KeyError as key_err:
+                # Added this check because of "unsupported datatype" error that prevented
+                # fully running comparisons on S5P_OFFL_L1B_IR_UVN collections.
+                v_attributes[name] = f"netCDF error: {str(key_err)}"
     else:
         the_variable = None
         v_dtype = ""


### PR DESCRIPTION
…sing attributes

GitHub Issue: #267 

### Description

This change catches the datatype KeyError and allows ncompare to continue generating the comparison report instead of erroring and exiting mid-comparison.

### Local test steps

Tested this on the `S5P_OFFL_L1B_IR_UVN` data collection from NASA Earthdata.

## PR Acceptance Checklist
* [ ] Unit tests added/updated and passing.
* [ ] Integration testing
* [ ] `CHANGELOG.md` updated
* [ ] Documentation updated (if needed).
