### PR TITLE
docstring cleanups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+### Changed
+
+- Clean up docstrings, especially removing types that are already annotated in function signature ([#274](https://github.com/nasa/ncompare/issues/274)) ([**@danielfromearth**](https://github.com/danielfromearth))
+
 ### Fixed
 
 - Catch "unsupported datatype" exception from netCDF library ([#268](https://github.com/nasa/ncompare/pull/268)) ([**@danielfromearth**](https://github.com/danielfromearth))

--- a/ncompare/console.py
+++ b/ncompare/console.py
@@ -43,8 +43,8 @@ def _cli(args: Optional[Sequence[str]]) -> argparse.Namespace:
 
     Parameters
     ----------
-    args : None or list[str]
-        if None, then argparse will use sys.argv[1:]
+    args
+        if None, then argparse will use `sys.argv[1:]`
     """
     parser = argparse.ArgumentParser(
         description="Compare the variables contained within two different NetCDF datasets"


### PR DESCRIPTION
GitHub Issue: #273 

### Description

This cleans up docstrings, removing duplicated type notations from docstrings where they are already annotated in the function signatures.

### Local test steps

n/a

## PR Acceptance Checklist
* [n/a] Unit tests added/updated and passing.
* [n/a] Integration testing
* [x] `CHANGELOG.md` updated
* [x] Documentation updated (if needed).


<!-- readthedocs-preview ncompare start -->
----
📚 Documentation preview 📚: https://ncompare--274.org.readthedocs.build/en/274/

<!-- readthedocs-preview ncompare end -->