### PR TITLE
Feature/issue 270 provide numerical output where zero means no differences found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Categorize counts of differences (including attributes) in a summary ([#276](https://github.com/nasa/ncompare/pull/276)) ([**@danielfromearth**](https://github.com/danielfromearth))
 - Include dimensions in variable attribute comparisons. ([#277](https://github.com/nasa/ncompare/pull/277)) ([**@danielfromearth**](https://github.com/danielfromearth))
+- Provide numerical output where zero means no differences found ([#278](https://github.com/nasa/ncompare/pull/278)) ([**@danielfromearth**](https://github.com/danielfromearth))
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -38,28 +38,21 @@ Compare the structure of two NetCDF files at the command line.
 
 ## Installing
 
-The latest release of `ncompare` can be installed with `mamba`, `conda` or `pip`.
-
-#### Using `mamba`
+The latest release of `ncompare` can be installed with `mamba`, `conda` or `pip`:
 
 ```bash
 mamba install -c conda-forge ncompare
 ```
-
-#### Using `conda`
-
 ```bash
 conda install -c conda-forge ncompare
 ```
-
-#### Using `pip`
-
 ```bash
 pip install ncompare
 ```
 
-## Usage
+## Usage Examples
 
+### At a command line:
 To compare two netCDF files,
 pass the filepaths for each of the two netCDF files directly to ncompare, as follows:
 
@@ -77,21 +70,22 @@ a common use of _ncompare_ may look like this example:
 ncompare S001G01.nc S001G01_SUBSET.nc --file-text subset_comparison.txt
 ```
 
-**A more complete usage demonstration with example output is shown in
-[this example notebook](https://ncompare.readthedocs.io/en/latest/example/ncompare-example-usage/).**
+### In a Python kernel:
 
-### Options
+```python
+from ncompare import compare
 
-- `-h`, `--help` : Show this help message and exit.
-- `--file-text` [FILE_PATH]: Text file to write output to.
-- `--file-csv` [FILE_PATH]: Comma-separated values (CSV) file to write output to.
-- `--file-xlsx` [FILE_PATH]: Excel file to write output to.
-- `--only-diffs` : Only display variables and attributes that are different
-- `--no-color` : Turn off all colorized output.
-- `--show-attributes` : Include variable attributes in the table that compares variables.
-- `--show-chunks` : Include chunk sizes in the table that compares variables.
-- `--column-widths` [WIDTH, WIDTH, WIDTH]: Width, in number of characters, of the three columns in the comparison report
-- `--version` : Show the current version and then exit.
+total_number_of_differences = compare(
+    "<netcdf file 1>", 
+    "<netcdf file 2>", 
+    only_diffs=True,
+    show_attributes=True,
+    show_chunks=True,
+)
+```
+
+
+### More complete usage demonstrations, with example output, are shown in [this example notebook](https://ncompare.readthedocs.io/en/latest/example/ncompare-example-usage/).
 
 ## Contributing
 

--- a/docs/example/ncompare-example-usage.ipynb
+++ b/docs/example/ncompare-example-usage.ipynb
@@ -24,6 +24,14 @@
    "id": "569c088b-0929-43c3-8d0f-6da3b6c89cce",
    "metadata": {},
    "source": [
+    "# Command Line Usage"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "14790bf9-9504-4823-9370-db738fe29355",
+   "metadata": {},
+   "source": [
     "## `ncompare`'s command line arguments, provided by the `--help` description"
    ]
   },
@@ -42,8 +50,9 @@
    "execution_count": 1,
    "id": "07e397b3-4964-4a90-b7f5-ae35185f86e5",
    "metadata": {
-    "jupyter": {
-     "is_executing": true
+    "ExecuteTime": {
+     "end_time": "2024-12-13T19:23:10.236545Z",
+     "start_time": "2024-12-13T19:23:09.323920Z"
     }
    },
    "outputs": [
@@ -114,7 +123,12 @@
    "cell_type": "code",
    "execution_count": 2,
    "id": "136bbeb8-6d74-4373-8ef7-1c20c1fe6afc",
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-12-13T19:23:10.245010Z",
+     "start_time": "2024-12-13T19:23:10.242690Z"
+    }
+   },
    "outputs": [],
    "source": [
     "from pathlib import Path\n",
@@ -140,7 +154,12 @@
    "cell_type": "code",
    "execution_count": 3,
    "id": "10a025b9-4483-4925-873e-6653b64441e3",
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-12-13T19:23:11.688286Z",
+     "start_time": "2024-12-13T19:23:10.323624Z"
+    }
+   },
    "outputs": [],
    "source": [
     "import requests\n",
@@ -174,7 +193,12 @@
    "cell_type": "code",
    "execution_count": 4,
    "id": "43cace42-aa55-469e-84d9-13a45115267e",
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-12-13T19:23:12.154657Z",
+     "start_time": "2024-12-13T19:23:11.695335Z"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -240,6 +264,7 @@
       "\u001b[0m Total # of non-shared attributes:                          0                          0\u001b[0m\n",
       "\u001b[0m\u001b[37m\u001b[0m\n",
       "Done.\u001b[0m\n",
+      "\u001b[0m0\u001b[0m\n",
       "\u001b[0m\u001b[0m"
      ]
     }
@@ -261,7 +286,12 @@
    "cell_type": "code",
    "execution_count": 5,
    "id": "c48728a0-1379-4a05-b7e6-ad50694510df",
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-12-13T19:23:12.577663Z",
+     "start_time": "2024-12-13T19:23:12.161049Z"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -359,6 +389,7 @@
       "['dimensions', 'dtype', 'shape']\u001b[0m\n",
       "\u001b[0m\u001b[37m\u001b[0m\n",
       "Done.\u001b[0m\n",
+      "\u001b[0m50\u001b[0m\n",
       "\u001b[0m\u001b[0m"
      ]
     }
@@ -379,7 +410,12 @@
    "cell_type": "code",
    "execution_count": 6,
    "id": "1dd4c51a-394c-4569-b8b1-053743e63cb9",
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-12-13T19:23:12.990375Z",
+     "start_time": "2024-12-13T19:23:12.583132Z"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -543,12 +579,242 @@
       "['_FillValue', 'axis', 'bounds', 'calendar', 'cell_method', 'cell_methods', 'chunksize', 'comment', 'coordinates', 'dimensions', 'dtype', 'long_name', 'missing_value', 'shape', 'standard_name', 'units', 'valid_max', 'valid_min', 'valid_range']\u001b[0m\n",
       "\u001b[0m\u001b[37m\u001b[0m\n",
       "Done.\u001b[0m\n",
+      "\u001b[0m114\u001b[0m\n",
       "\u001b[0m\u001b[0m"
      ]
     }
    ],
    "source": [
     "! ncompare --show-attributes --show-chunks --column-widths 33 30 30 {file_names[0]} {file_names[2]}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7e1344892c25806a",
+   "metadata": {},
+   "source": [
+    "# Python Package Usage Example\n",
+    "----"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "525f98b5cbb923",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-12-13T19:23:13.326162Z",
+     "start_time": "2024-12-13T19:23:12.996001Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "from ncompare import compare"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "f3363c6630447104",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-12-13T19:23:13.428938Z",
+     "start_time": "2024-12-13T19:23:13.330402Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "File A: gpcp_v02r03_monthly_d202301_c20230411.nc\n",
+      "File B: PERSIANN-CDR_v01r01_20230419_c20231030.nc\n",
+      "\n",
+      "Root-level Dimensions:\n",
+      "\tAre all items the same? ---> False.  (2 items are shared, out of 6 total.)\n",
+      "\tWhich items are different?\n",
+      "                                                           File A                         File B\n",
+      "                               #00 ------------------------------ ------------------('lat', 480)\n",
+      "                               #01 --------------('latitude', 72) ------------------------------\n",
+      "                               #02 ------------------------------ -----------------('lon', 1440)\n",
+      "                               #03 ------------('longitude', 144) ------------------------------\n",
+      "\n",
+      "Root-level Groups:\n",
+      "\tAre all items the same? ---> True.  (No items exist.)\n",
+      "\n",
+      "All variables:\n",
+      "                                                           File A                         File B\n",
+      "                     All Variables                                                              \n",
+      "                                 - ------------------------------ ------------------------------\n",
+      "                                                                                                \n",
+      "                         GROUP #00 -----------------------------/ -----------------------------/\n",
+      "           num variables in group:                              8                              6\n",
+      "                                 - ------------------------------ ------------------------------\n",
+      "               -----VARIABLE-----:                                                           lat\n",
+      "                            dtype:                                                       float32\n",
+      "                       dimensions:                                                      ('lat',)\n",
+      "                            shape:                                                        (480,)\n",
+      "                        chunksize:                                                    contiguous\n",
+      "                           bounds:                                                      lat_bnds\n",
+      "                        long_name:                                                      latitude\n",
+      "                    standard_name:                                                      latitude\n",
+      "                            units:                                                 degrees_north\n",
+      "                        valid_max:                                                          60.0\n",
+      "                        valid_min:                                                         -60.0\n",
+      "               -----VARIABLE-----:                                                      lat_bnds\n",
+      "                            dtype:                                                       float32\n",
+      "                       dimensions:                                                 ('lat', 'nv')\n",
+      "                            shape:                                                      (480, 2)\n",
+      "                        chunksize:                                                    contiguous\n",
+      "               -----VARIABLE-----:                     lat_bounds                               \n",
+      "                            dtype:                        float32                               \n",
+      "                       dimensions:             ('latitude', 'nv')                               \n",
+      "                            shape:                        (72, 2)                               \n",
+      "                        chunksize:                     contiguous                               \n",
+      "                          comment: latitude values at the north and south bounds of each pixel.                               \n",
+      "               -----VARIABLE-----:                       latitude                               \n",
+      "                            dtype:                        float32                               \n",
+      "                       dimensions:                  ('latitude',)                               \n",
+      "                            shape:                          (72,)                               \n",
+      "                        chunksize:                     contiguous                               \n",
+      "                             axis:                              Y                               \n",
+      "                           bounds:                     lat_bounds                               \n",
+      "                        long_name:                       Latitude                               \n",
+      "                    standard_name:                       latitude                               \n",
+      "                            units:                  degrees_north                               \n",
+      "                      valid_range:             [-90.0, 90.0, ...]                               \n",
+      "               -----VARIABLE-----:                                                           lon\n",
+      "                            dtype:                                                       float32\n",
+      "                       dimensions:                                                      ('lon',)\n",
+      "                            shape:                                                       (1440,)\n",
+      "                        chunksize:                                                    contiguous\n",
+      "                           bounds:                                                      lon_bnds\n",
+      "                        long_name:                                                     longitude\n",
+      "                    standard_name:                                                     longitude\n",
+      "                            units:                                                  degrees_east\n",
+      "                        valid_max:                                                         360.0\n",
+      "                        valid_min:                                                           0.0\n",
+      "               -----VARIABLE-----:                                                      lon_bnds\n",
+      "                            dtype:                                                       float32\n",
+      "                       dimensions:                                                 ('lon', 'nv')\n",
+      "                            shape:                                                     (1440, 2)\n",
+      "                        chunksize:                                                    contiguous\n",
+      "               -----VARIABLE-----:                     lon_bounds                               \n",
+      "                            dtype:                        float32                               \n",
+      "                       dimensions:            ('longitude', 'nv')                               \n",
+      "                            shape:                       (144, 2)                               \n",
+      "                        chunksize:                     contiguous                               \n",
+      "                          comment: longitude values at the west and east bounds of each pixel.                               \n",
+      "               -----VARIABLE-----:                      longitude                               \n",
+      "                            dtype:                        float32                               \n",
+      "                       dimensions:                 ('longitude',)                               \n",
+      "                            shape:                         (144,)                               \n",
+      "                        chunksize:                     contiguous                               \n",
+      "                             axis:                              X                               \n",
+      "                           bounds:                     lon_bounds                               \n",
+      "                        long_name:                      Longitude                               \n",
+      "                    standard_name:                      longitude                               \n",
+      "                            units:                   degrees_east                               \n",
+      "                      valid_range:              [0.0, 360.0, ...]                               \n",
+      "               -----VARIABLE-----:                         precip                               \n",
+      "                            dtype:                        float32                               \n",
+      "                       dimensions: ('time', 'latitude', 'longitude')                               \n",
+      "                            shape:                   (1, 72, 144)                               \n",
+      "                        chunksize:                     contiguous                               \n",
+      "                     cell_methods:          area: mean time: mean                               \n",
+      "                      coordinates:        time latitude longitude                               \n",
+      "                        long_name: NOAA Climate Data Record (CDR) of GPCP Monthly Satellite-Gauge Combined Precipitation                               \n",
+      "                    missing_value:                        -9999.0                               \n",
+      "                    standard_name:           precipitation amount                               \n",
+      "                            units:                         mm/day                               \n",
+      "                      valid_range:              [0.0, 100.0, ...]                               \n",
+      "               -----VARIABLE-----:                   precip_error                               \n",
+      "                            dtype:                        float32                               \n",
+      "                       dimensions: ('time', 'latitude', 'longitude')                               \n",
+      "                            shape:                   (1, 72, 144)                               \n",
+      "                        chunksize:                     contiguous                               \n",
+      "                      coordinates:        time latitude longitude                               \n",
+      "                        long_name: NOAA CDR of GPCP Satellite-Gauge Combined Precipitation Error                               \n",
+      "                    missing_value:                        -9999.0                               \n",
+      "                            units:                         mm/day                               \n",
+      "                      valid_range:              [0.0, 100.0, ...]                               \n",
+      "               -----VARIABLE-----:                                                 precipitation\n",
+      "                            dtype:                                                       float32\n",
+      "                       dimensions:                                        ('time', 'lon', 'lat')\n",
+      "                            shape:                                                (1, 1440, 480)\n",
+      "                        chunksize:                                                [1, 1440, 480]\n",
+      "                       _FillValue:                                                          -1.0\n",
+      "                      cell_method:                                                           sum\n",
+      "                        long_name:                                NOAA Climate Data Record of PERSIANN-CDR daily precipitation\n",
+      "                    missing_value:                                                       -9999.0\n",
+      "                    standard_name:                                          precipitation_amount\n",
+      "                            units:                                                            mm\n",
+      "                        valid_max:                                                      999999.0\n",
+      "                        valid_min:                                                           0.0\n",
+      "               -----VARIABLE-----:                           time                           time\n",
+      "                            dtype:                        float32                          int32\n",
+      "                             axis:                              T                               \n",
+      "                           bounds:                    time_bounds                               \n",
+      "                         calendar:                      Gregorian                               \n",
+      "                            units: days since 1970-01-01 00:00:00 0:00    days since 1979-01-01 0:0:0\n",
+      "               -----VARIABLE-----:                    time_bounds                               \n",
+      "                            dtype:                        float32                               \n",
+      "                       dimensions:                 ('time', 'nv')                               \n",
+      "                            shape:                         (1, 2)                               \n",
+      "                        chunksize:                     contiguous                               \n",
+      "                          comment: time bounds for each time value                               \n",
+      "                                 - ------------------------------ ------------------------------\n",
+      "                           SUMMARY ------------------------------ ------------------------------\n",
+      "      Total # of shared variables:                              1                              1\n",
+      "  Total # of non-shared variables:                              7                              5\n",
+      "         Total # of shared groups:                              0                              0\n",
+      "     Total # of non-shared groups:                              0                              0\n",
+      "     Total # of shared attributes:                              5                              5\n",
+      " Total # of non-shared attributes:                             60                             42\n",
+      "\n",
+      "Differences were found in these attributes:\n",
+      "\n",
+      "['_FillValue', 'axis', 'bounds', 'calendar', 'cell_method', 'cell_methods', 'chunksize', 'comment', 'coordinates', 'dimensions', 'dtype', 'long_name', 'missing_value', 'shape', 'standard_name', 'units', 'valid_max', 'valid_min', 'valid_range']\n",
+      "\n",
+      "Done.\n"
+     ]
+    }
+   ],
+   "source": [
+    "total_number_of_differences = compare(\n",
+    "    file_names[0],\n",
+    "    file_names[2],\n",
+    "    only_diffs=True,\n",
+    "    show_attributes=True,\n",
+    "    show_chunks=True,\n",
+    "    column_widths=[33, 30, 30],\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b8b3f36e-c4ed-4392-81a8-fedcbd6fa3c8",
+   "metadata": {},
+   "source": [
+    "The output of `ncompare` is the total number of differences (across _variables_, _groups_, and _attributes_):"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "d93e1ef4-4bf9-4e48-b166-d42ca2ff42e9",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "114\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(total_number_of_differences)"
    ]
   },
   {

--- a/ncompare/__init__.py
+++ b/ncompare/__init__.py
@@ -24,3 +24,15 @@
 # See the License for the specific language governing permissions and limitations under the License.
 
 """Main code for comparing NetCDF files."""
+
+from importlib.metadata import version
+
+from .core import (
+    compare,
+)
+
+__all__ = [
+    "compare",
+]
+
+__version__ = version("ncompare")

--- a/ncompare/console.py
+++ b/ncompare/console.py
@@ -108,10 +108,11 @@ def main() -> None:  # pragma: no cover
     delattr(args, "version")
 
     try:
-        compare(**vars(args))
+        total_diff_count = compare(**vars(args))
     except Exception:  # pylint: disable=broad-exception-caught
         print(traceback.format_exc())
         sys.exit(1)
+    print(total_diff_count)
     sys.exit(0)  # a clean, no-issue, exit
 
 

--- a/ncompare/core.py
+++ b/ncompare/core.py
@@ -395,7 +395,7 @@ def _print_summary_count_comparison_side_by_side(
 
 
 def _print_group_details_side_by_side(
-    out,
+    out: Outputter,
     group_a: Union[netCDF4.Dataset, netCDF4.Group],
     group_a_name: str,
     group_b: Union[netCDF4.Dataset, netCDF4.Group],

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -71,6 +71,10 @@ def test_no_error_compare_2groupsTo1Subgroup(
     compare_ba(ds_3dims_3vars_4coords_2groups, ds_3dims_3vars_4coords_1subgroup)
 
 
+def test_zero_for_comparison_with_no_differences(ds_3dims_3vars_4coords_1subgroup):
+    assert compare(ds_3dims_3vars_4coords_1subgroup, ds_3dims_3vars_4coords_1subgroup) == 0
+
+
 def test_var_properties(ds_3dims_3vars_4coords_1group):
     with nc.Dataset(ds_3dims_3vars_4coords_1group) as ds:
         result = _var_properties(ds.groups["Group1"], varname="step")


### PR DESCRIPTION
GitHub Issue: #270 

### Description

This change makes it so there is a return value from the `ncompare.compare` function. The return value represents the total number of differences found (across variables, groups, and attributes). This enables for `ncompare.compare` to be used as a quick check, with `ncompare.compare(file_1, file_2) == 0` representing no structural differences discovered between two netCDF files.

### Local test steps

All tests passed.

## PR Acceptance Checklist
* [x] Unit tests added/updated and passing.
* [n/a] Integration testing
* [x] `CHANGELOG.md` updated
* [x] Documentation updated (if needed).


<!-- readthedocs-preview ncompare start -->
----
📚 Documentation preview 📚: https://ncompare--278.org.readthedocs.build/en/278/

<!-- readthedocs-preview ncompare end -->