### PR TITLE
Feature/issue 311 pypi on release publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,42 @@
+name: Publish on Release
+
+on:
+  release:
+    types: [published] # This ensures the workflow runs only after a release is finalized
+
+env:
+  PYTHON_VERSION: "3.11"
+
+jobs:
+  build-and-publish:
+    environment: pypi
+    permissions:
+      id-token: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0 # Fetch all history for accurate versioning/changelogs
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+
+      - name: Verify version matches git tag
+        run: scripts/verify_tag.sh
+
+      - name: Install dependencies
+        run: uv sync --no-dev --frozen
+
+      - name: Build package
+        run: uv build
+
+      - name: Publish to PyPI
+        run: uv publish

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -20,7 +20,7 @@ on:
 
 jobs:
   build_and_test:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         python-version: [ '3.11', '3.12', '3.13', '3.14' ]

--- a/.github/workflows/version-and-build.yml
+++ b/.github/workflows/version-and-build.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-      packages: write
+      id-token: write
 
     steps:
       - name: Checkout
@@ -186,13 +186,5 @@ jobs:
           path: dist/*
 
       - name: Publish to Test PyPI
-        if: steps.version.outputs.publish == 'true' && steps.version.outputs.venue == 'uat'
-        env:
-          UV_PUBLISH_TOKEN: ${{ secrets.PYPI_TOKEN_TESTPYPI }}
+        if: steps.version.outputs.publish == 'true'
         run: uv publish --publish-url https://test.pypi.org/legacy/
-
-      - name: Publish to PyPI
-        if: steps.version.outputs.publish == 'true' && steps.version.outputs.venue == 'ops'
-        env:
-          UV_PUBLISH_TOKEN: ${{ secrets.PYPI_TOKEN_PYPI }}
-        run: uv publish

--- a/.github/workflows/version-and-build.yml
+++ b/.github/workflows/version-and-build.yml
@@ -2,7 +2,7 @@ name: Version and Build
 
 on:
   push:
-    branches: [develop, main, 'release/**', 'hotfix/**', 'feature/**', 'issue/**', 'issues/**', 'docs/**']
+    branches: [develop, main, 'release/**', 'hotfix/**', 'feature/**', 'issue/**', 'docs/**']
   workflow_dispatch:
 
 env:
@@ -53,120 +53,30 @@ jobs:
         id: version
         run: |
           BRANCH="${GITHUB_REF#refs/heads/}"
-          echo "Processing branch: $BRANCH"
-
-          case "$BRANCH" in
-            develop)
-              echo "📦 Bumping develop alpha"
-              bump-my-version bump pre_number
-              VENUE=sit
-              PUBLISH=true
-              ;;
-
-            release/*)
-              echo "🎯 Bumping release"
-              CURRENT=$(bump-my-version show current_version)
-
-              if [[ "$CURRENT" == *"a"* ]]; then
-                echo "  First release push: Alpha → RC1"
-                bump-my-version bump pre_label
-
-                # Commit the release branch bump before switching branches
-                git commit -am "Bump to RC1 [skip ci]"
-                git push
-
-                # Auto-bump develop to next minor
-                echo ""
-                RELEASE_VERSION="${BRANCH#release/}"
-                bash scripts/bump_develop_after_release.sh "$RELEASE_VERSION"
-                echo ""
-
-                # Return to release branch
-                git checkout "$BRANCH"
-              else
-                echo "  Incrementing RC"
-                bump-my-version bump pre_number
-              fi
-
-              VENUE=uat
-              PUBLISH=true
-              ;;
-
-            main)
-              echo "🎉 Stripping to final release"
-              bump-my-version bump pre_label
-              VENUE=ops
-              PUBLISH=true
-              TAG=true
-              ;;
-
-            hotfix/*)
-              echo "🔧 Bumping hotfix patch"
-              CURRENT=$(bump-my-version show current_version)
-              if [[ "$CURRENT" == *"rc"* ]] || [[ "$CURRENT" == *"a"* ]]; then
-                echo "  Stripping pre-release label first"
-                bump-my-version bump pre_label
-              fi
-              bump-my-version bump patch
-              VENUE=ops
-              PUBLISH=true
-              ;;
-
-            feature/*|issue/*|issues/*|docs/*)
-              echo "🌟 Feature branch: adding local identifier"
-              CURRENT=$(bump-my-version show current_version)
-              LOCAL_ID="+$(git rev-parse --short ${GITHUB_SHA})"
-              VERSION="${CURRENT}${LOCAL_ID}"
-              VENUE=dev
-              PUBLISH=false
-              ;;
-
-            *)
-              echo "⏭️  Unknown branch, no version bump"
-              CURRENT=$(bump-my-version show current_version)
-              VERSION="$CURRENT"
-              VENUE=dev
-              PUBLISH=false
-              ;;
-          esac
-
-          # Set VERSION if not already set (for feature branches)
-          if [ -z "$VERSION" ]; then
-            VERSION=$(bump-my-version show current_version)
-          fi
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
-          echo "venue=$VENUE" >> $GITHUB_OUTPUT
-          echo "publish=$PUBLISH" >> $GITHUB_OUTPUT
-          echo "tag=${TAG:-false}" >> $GITHUB_OUTPUT
-
-          echo ""
-          echo "📌 Version: $VERSION"
-          echo "🎯 Venue: $VENUE"
+          bash scripts/version_bump.sh "$BRANCH"
 
       - name: Commit version bump
         if: |
-          github.ref == 'refs/heads/develop' ||
-          github.ref == 'refs/heads/main' ||
-          startsWith(github.ref, 'refs/heads/release/') ||
-          startsWith(github.ref, 'refs/heads/hotfix/')
+          steps.version.outputs.already_committed == 'false' && (
+            github.ref == 'refs/heads/develop' ||
+            github.ref == 'refs/heads/main' ||
+            startsWith(github.ref, 'refs/heads/release/') ||
+            startsWith(github.ref, 'refs/heads/hotfix/')
+          )
         run: |
-          # Check if there are uncommitted changes
           if [[ -n $(git status -s) ]]; then
             git commit -am "Bump version to ${{ steps.version.outputs.version }} [skip ci]"
+            git push || {
+              echo "❌ Failed to push to remote"
+              exit 1
+            }
             echo "✅ Version bumped and committed"
           else
             echo "ℹ️  No version changes to commit"
           fi
-          
-          # Push (whether we just committed or committed earlier)
-          git push
-          echo "✅ Pushed to remote"
 
       - name: Create Git tag
-        if: |
-          github.ref == 'refs/heads/develop' ||
-          github.ref == 'refs/heads/main' ||
-          startsWith(github.ref, 'refs/heads/release/')
+        if: github.ref == 'refs/heads/main'
         run: |
           VERSION="${{ steps.version.outputs.version }}"
           git tag -a "$VERSION" -m "Version $VERSION"

--- a/.github/workflows/version-and-build.yml
+++ b/.github/workflows/version-and-build.yml
@@ -20,7 +20,7 @@ jobs:
   # Main build job
   build:
     needs: run_tests
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     permissions:
       contents: write
       packages: write

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.14.0] - 2025-12-30
 
+_Updates base Python version from 3.9 to 3.11._
+
 ### Changed
 
-- update the default python version from 3.9 to 3.10 ([#323](https://github.com/nasa/stitchee/pull/323))([**@danielfromearth**](https://github.com/danielfromearth))
-- Implement uv dependency management and versioning with bump-my-version ([#325](https://github.com/nasa/stitchee/issues/325))([**@danielfromearth**](https://github.com/danielfromearth))
-- Download ICESat-2 ATL06 granules for integration testing instead of using git lfs ([#327](https://github.com/nasa/stitchee/pull/327))([**@danielfromearth**](https://github.com/danielfromearth))
-- Fix python version in matrixed GitHub Actions tests ([#329](https://github.com/nasa/stitchee/pull/329))([**@danielfromearth**](https://github.com/danielfromearth))
+- Implement uv dependency management and versioning with bump-my-version ([#325](https://github.com/nasa/ncompare/issues/325))([**@danielfromearth**](https://github.com/danielfromearth))
+- Download ICESat-2 ATL06 granules for integration testing instead of using git lfs (Updates Python version from 3.10 to 3.11) ([#327](https://github.com/nasa/ncompare/pull/327))([**@danielfromearth**](https://github.com/danielfromearth))
+- Refactor CI/CD workflows for releasing on publish, improve maintainability ([#333](https://github.com/nasa/ncompare/pull/33))([**@danielfromearth**](https://github.com/danielfromearth))
+- Update the default python version from 3.9 to 3.10 ([#323](https://github.com/nasa/ncompare/pull/323))([**@danielfromearth**](https://github.com/danielfromearth))
+
+### Fixed
+- Fix python version in matrixed GitHub Actions tests ([#329](https://github.com/nasa/ncompare/pull/329))([**@danielfromearth**](https://github.com/danielfromearth))
 
 ## [1.13.1] - 2025-01-08
 

--- a/scripts/verify_tag.sh
+++ b/scripts/verify_tag.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+set -e
+
+git_tag=$(git describe --tags --abbrev=0)
+current_version=v$(grep -m 1 version pyproject.toml | cut -d'"' -f 2)
+
+echo "${git_tag} ${current_version}"
+
+if [ "$current_version" == "$git_tag" ]; then
+  echo "Version does match git tag"
+else
+  echo "Version does not match git tag! pyproject.toml: ${current_version} vs Tag: ${git_tag} "
+  exit 1
+fi

--- a/scripts/version_bump.sh
+++ b/scripts/version_bump.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+set -e
+
+BRANCH="${1}"
+echo "Processing branch: $BRANCH"
+
+ALREADY_COMMITTED=false
+PUBLISH=false  # Default: most branches don't publish
+
+case "$BRANCH" in
+  develop)
+    echo "📦 Bumping develop alpha"
+    bump-my-version bump pre_number
+    ;;
+
+  release/*)
+    echo "🎯 Bumping release"
+    CURRENT=$(bump-my-version show current_version)
+
+    if [[ "$CURRENT" == *"a"* ]]; then
+      echo "  Alpha → RC1"
+      bump-my-version bump pre_label
+      git commit -am "Bump to RC1 [skip ci]" && git push
+      ALREADY_COMMITTED=true
+
+      # Auto-bump develop
+      RELEASE_VERSION="${BRANCH#release/}"
+      if [ -f "scripts/bump_develop_after_release.sh" ]; then
+        bash scripts/bump_develop_after_release.sh "$RELEASE_VERSION" || exit 1
+      fi
+      git checkout "$BRANCH"
+    else
+      echo "  Incrementing RC"
+      bump-my-version bump pre_number
+    fi
+    PUBLISH=true
+    ;;
+
+  main)
+    echo "🎉 Stripping to final release"
+    bump-my-version bump pre_label
+    ;;
+
+  hotfix/*)
+    echo "🔧 Bumping hotfix patch"
+    CURRENT=$(bump-my-version show current_version)
+    [[ "$CURRENT" =~ (rc|a) ]] && bump-my-version bump pre_label
+    bump-my-version bump patch
+    ;;
+
+  feature/*|issue/*|docs/*|*)
+    echo "🌟 Branch: no version bump"
+    ;;
+esac
+
+VERSION=$(bump-my-version show current_version)
+
+# Output for GitHub Actions
+{
+  echo "version=$VERSION"
+  echo "publish=$PUBLISH"
+  echo "already_committed=$ALREADY_COMMITTED"
+} >> "$GITHUB_OUTPUT"
+
+echo "📌 Version: $VERSION | 📤 Publish: $PUBLISH"

--- a/uv.lock
+++ b/uv.lock
@@ -1648,7 +1648,7 @@ wheels = [
 
 [[package]]
 name = "ncompare"
-version = "1.14.0a27"
+version = "1.14.0rc2"
 source = { editable = "." }
 dependencies = [
     { name = "colorama" },


### PR DESCRIPTION
GitHub Issue: #311

## Refactor CI/CD workflows for releasing on publish, improve maintainability

### Changes

**`publish.yml` and shell script:**
- Fix checkout to use release tag instead of default branch
- Configure OIDC trusted publishing for PyPI (removed token-based auth)
- Add `verify_tag.sh`

**`version-and-build.yml`:**
- Extract 80-line bash case statement to external script `scripts/version_bump.sh` for better testability and maintainability (191 → ~110 lines)
- Fix double-push issue on release branches with `ALREADY_COMMITTED` flag
- Only create Git tags on `main` branch (prevents alpha/RC tag clutter)
- Clarify publishing logic
- Add error handling for git operations
- Remove unused `packages: write` permission
- Simplify conditional logic for better readability

### Overview of integration done

_Explain how this change was integration tested. Provide screenshots or logs if appropriate. An example of this would be a local Harmony deployment._

## PR Acceptance Checklist
* [x] Unit tests added/updated and passing.
* [x] Integration testing
* [x] `CHANGELOG.md` updated
* [ ] Documentation updated (if needed).


<!-- readthedocs-preview ncompare start -->
----
📚 Documentation preview 📚: https://ncompare--333.org.readthedocs.build/en/333/

<!-- readthedocs-preview ncompare end -->