### PR TITLE
Bug: resolve HDF5 references against the correct file during traversal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Common Changelog](https://common-changelog.org/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Resolve each variable's HDF5 object-reference attributes against its own file (File B was incorrectly dereferenced against File A), and use the correct parent-group name when building nested group paths during traversal ([#341](https://github.com/nasa/ncompare/issues/341)) ([**@danielfromearth**](https://github.com/danielfromearth))
+
 ## [1.14.0] - 2025-12-30
 
 _Updates base Python version from 3.9 to 3.11._

--- a/ncompare/Comparison.py
+++ b/ncompare/Comparison.py
@@ -180,13 +180,15 @@ class Comparison:
 
         # Go through each variable in the current group.
         for variable_pair in common_elements(vars_a_sorted, vars_b_sorted):
-            # Get and print the properties of each variable
+            # Get and print the properties of each variable.
+            # Note: each variable's object-reference attributes must be resolved
+            # against its *own* file, so File B uses open_file2 (not open_file1).
             self._print_var_properties_side_by_side(
                 self._create_var_properties(
                     group_a, variable_pair[1], original_dataset=self.open_file1
                 ),
                 self._create_var_properties(
-                    group_b, variable_pair[2], original_dataset=self.open_file1
+                    group_b, variable_pair[2], original_dataset=self.open_file2
                 ),
             )
 
@@ -382,7 +384,7 @@ class Comparison:
             )
             subnode_a_subgroups = get_subgroups(subnode_a, file_type=self.file_types)
 
-            subnode_b_name = node_a_name + "/" + subgroup_b_name if subgroup_b_name else ""
+            subnode_b_name = node_b_name + "/" + subgroup_b_name if subgroup_b_name else ""
             subnode_b = (
                 node_b[subgroup_b_name]
                 if (subgroup_b_name and (subgroup_b_name in node_b_subgroups))

--- a/tests/test_hdf5_references.py
+++ b/tests/test_hdf5_references.py
@@ -1,0 +1,81 @@
+# Copyright 2024 United States Government as represented by the Administrator of the
+# National Aeronautics and Space Administration. All Rights Reserved.
+#
+# This software calls the following third-party software,
+# which is subject to the terms and conditions of its licensor, as applicable.
+# Users must license their own copies; the links are provided for convenience only.
+#
+# colorama - BSD-3-Clause - https://opensource.org/licenses/BSD-3-Clause
+# netCDF4 - MIT License - https://opensource.org/licenses/MIT
+# numpy - BSD-3-Clause - https://opensource.org/licenses/BSD-3-Clause
+# openpyxl - MIT License - https://opensource.org/licenses/MIT
+# xarray - Apache License, version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
+# Python Standard Library - Python Software Foundation (PSF) License Agreement-
+#   https://docs.python.org/3/license.html#psf-license
+#
+# The ncompare: NetCDF structural comparison tool platform is licensed under the
+# Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+
+"""Tests for HDF5-specific handling, e.g., object-reference attributes."""
+
+import h5py
+import numpy as np
+import pytest
+
+from ncompare.Comparison import Comparison
+from ncompare.printing import Outputter
+from ncompare.utility_types import FileToCompare
+
+
+def _build_hdf5_with_reference(path, target_name: str) -> None:
+    """Create an HDF5 file whose `data` variable has an object-reference attribute.
+
+    The `my_ref` attribute points to a target dataset named `target_name`, mimicking
+    reference attributes (such as `DIMENSION_LIST`) that netCDF/HDF5 writers produce.
+    """
+    with h5py.File(path, "w") as f:
+        target = f.create_dataset(target_name, data=np.arange(3))
+        variable = f.create_dataset("data", data=np.arange(4))
+        ref_array = np.empty((1, 1), dtype=h5py.ref_dtype)
+        ref_array[0, 0] = target.ref
+        variable.attrs.create("my_ref", data=ref_array)
+
+
+@pytest.fixture(scope="function")
+def hdf5_reference_pair(tmp_path):
+    """A pair of HDF5 files whose `data` variable references differently-named targets."""
+    path_a = tmp_path / "ref_a.h5"
+    path_b = tmp_path / "ref_b.h5"
+    _build_hdf5_with_reference(path_a, target_name="target_alpha")
+    _build_hdf5_with_reference(path_b, target_name="target_beta")
+    return path_a, path_b
+
+
+def test_hdf5_reference_attribute_resolves_against_its_own_file(hdf5_reference_pair):
+    """File B's object references must be resolved against File B, not File A.
+
+    Regression test for a bug where both variables' reference attributes were
+    dereferenced against File A's open handle. With that bug, File B's `my_ref`
+    resolved to File A's target name, so the differing references were reported as
+    identical and `my_ref` never appeared among the differing attributes.
+    """
+    path_a, path_b = hdf5_reference_pair
+    file_a = FileToCompare(path=path_a, type="hdf5")
+    file_b = FileToCompare(path=path_b, type="hdf5")
+
+    with Outputter(keep_print_history=True) as out:
+        comparison = Comparison(
+            file_a, file_b, out, show_chunks=False, show_attributes=True
+        )
+        comparison.run_through_comparisons()
+
+    # Because the references point to differently-named targets, correctly resolving
+    # each against its own file yields "/target_alpha" vs "/target_beta" -- a difference.
+    assert "my_ref" in comparison.num_attribute_diffs["difference_types"]

--- a/tests/test_hdf5_references.py
+++ b/tests/test_hdf5_references.py
@@ -71,9 +71,7 @@ def test_hdf5_reference_attribute_resolves_against_its_own_file(hdf5_reference_p
     file_b = FileToCompare(path=path_b, type="hdf5")
 
     with Outputter(keep_print_history=True) as out:
-        comparison = Comparison(
-            file_a, file_b, out, show_chunks=False, show_attributes=True
-        )
+        comparison = Comparison(file_a, file_b, out, show_chunks=False, show_attributes=True)
         comparison.run_through_comparisons()
 
     # Because the references point to differently-named targets, correctly resolving


### PR DESCRIPTION
GitHub Issue: #341

### Description

Two correctness fixes in the group/variable hierarchy traversal (`Comparison.py`):

1. **HDF5 reference handle.** File B's variable properties were built with
   `original_dataset=self.open_file1`, so File B's object-reference attributes
   (e.g. `DIMENSION_LIST`) were dereferenced against File A. This now passes
   `self.open_file2`. (`open_file2` was previously assigned but never read.)
2. **Group path prefix.** `subnode_b_name` was built from `node_a_name` instead
   of `node_b_name`. Masked today because subgroups are matched by name equality,
   but incorrect and fragile; corrected for consistency with the File A branch.

### Local test steps

- Added `tests/test_hdf5_references.py`: builds an HDF5 file pair whose `data`
  variable carries an object-reference attribute (`my_ref`) pointing to
  differently-named target datasets, runs the comparison, and asserts `my_ref`
  appears among the differing attributes — i.e. File B's reference resolves
  against File B (`/target_beta`) rather than File A (`/target_alpha`).
- Verified red→green: the new test fails on the pre-fix code (`my_ref` resolves
  identically and is absent from the differing-attributes set) and passes after
  the fix.
- `uv run pytest tests` → 26 passed, 2 deselected. `ruff check` clean.

### Overview of integration done

Structural comparison of local HDF5 fixtures with object-reference attributes.
No external services involved.

## PR Acceptance Checklist
* [x] Unit tests added/updated and passing.
* [ ] Integration testing
* [x] `CHANGELOG.md` updated
* [ ] Documentation updated (if needed).

---
_Note: #2 is not independently observable through current behavior (it is masked
by name-equality matching), so it is covered by the code correction rather than a
dedicated test._


<!-- readthedocs-preview ncompare start -->
----
📚 Documentation preview 📚: https://ncompare--342.org.readthedocs.build/en/342/

<!-- readthedocs-preview ncompare end -->