### PR TITLE
fix: resolve File B's HDF5 references against File B

### DIFF
--- a/ncompare/Comparison.py
+++ b/ncompare/Comparison.py
@@ -186,7 +186,7 @@ class Comparison:
                     group_a, variable_pair[1], original_dataset=self.open_file1
                 ),
                 self._create_var_properties(
-                    group_b, variable_pair[2], original_dataset=self.open_file1
+                    group_b, variable_pair[2], original_dataset=self.open_file2
                 ),
             )
 
@@ -382,7 +382,7 @@ class Comparison:
             )
             subnode_a_subgroups = get_subgroups(subnode_a, file_type=self.file_types)
 
-            subnode_b_name = node_a_name + "/" + subgroup_b_name if subgroup_b_name else ""
+            subnode_b_name = node_b_name + "/" + subgroup_b_name if subgroup_b_name else ""
             subnode_b = (
                 node_b[subgroup_b_name]
                 if (subgroup_b_name and (subgroup_b_name in node_b_subgroups))

--- a/tests/test_h5_ref_resolution.py
+++ b/tests/test_h5_ref_resolution.py
@@ -1,0 +1,56 @@
+"""File B's HDF5 object references must resolve against File B.
+
+_create_var_properties(group_b, ...) used to pass original_dataset=open_file1,
+so reference attributes (e.g. DIMENSION_LIST) of File B's variables were
+dereferenced against File A, producing wrong names or spurious diffs.
+Regression for #341.
+"""
+
+import h5py
+import numpy as np
+import pytest
+
+from ncompare.core import compare
+
+
+@pytest.fixture
+def differing_ref_pair(tmp_path):
+    """Two HDF5 files whose /var variables carry a reference attribute
+    pointing to differently-named target datasets within each file."""
+    path_a = tmp_path / "file_a.h5"
+    path_b = tmp_path / "file_b.h5"
+
+    for path, target_name in ((path_a, "target_in_a"), (path_b, "target_in_b")):
+        with h5py.File(path, "w") as f:
+            target = f.create_dataset(target_name, data=np.arange(4, dtype="f4"))
+            var = f.create_dataset("var", data=np.zeros(4, dtype="f4"))
+            # An object reference attribute shaped like DIMENSION_LIST.
+            var.attrs["ref_attr"] = np.array([[target.ref]], dtype=h5py.ref_dtype)
+
+    return path_a, path_b
+
+
+def test_file_b_references_resolve_against_file_b(tmp_path, differing_ref_pair, capsys):
+    path_a, path_b = differing_ref_pair
+    output_path = tmp_path / "out.txt"
+
+    compare(
+        path_a,
+        path_b,
+        file_text=output_path,
+        show_chunks=False,
+        show_attributes=True,
+    )
+
+    text = output_path.read_text()
+
+    # The reference-attribute row must show each file's own target: File A's
+    # reference resolved against File A and File B's against File B. Under
+    # the bug both columns resolved against File A, printing File A's target
+    # name twice.
+    ref_attr_lines = [
+        line for line in text.splitlines() if line.strip().startswith("ref_attr:")
+    ]
+    assert ref_attr_lines, "expected the ref_attr attribute row in the output"
+    assert "/target_in_a" in ref_attr_lines[0]
+    assert "/target_in_b" in ref_attr_lines[0]


### PR DESCRIPTION
Fixes #341.

## Summary

Two corrections in the HDF5 traversal:

1. **File B's references resolved against File A.** `_create_var_properties` was called with `original_dataset=self.open_file1` for **both** files, so `__name_from_h5_ref` dereferenced File B's object-reference attributes (e.g. `DIMENSION_LIST`) against File A's open file — printing File A's names for File B's variables, or spurious diffs, for any file pair whose variables carry reference attributes. Tellingly, `self.open_file2` was assigned and never read. File B now gets `self.open_file2`.
2. **`subnode_b_name` built from the wrong parent.** `_dataset_pair_iterator` prefixed subgroup paths with `node_a_name` for the B side. Not independently observable today (subgroups are matched by name equality, so shared groups always share a path prefix) but wrong and fragile — now built from `node_b_name`.

## Testing

Added `tests/test_h5_ref_resolution.py`: two HDF5 files whose `/var` variables carry a reference attribute pointing to differently-named targets (`/target_in_a`, `/target_in_b`); a full `compare()` run must print a `ref_attr` row showing **each file's own target** (`/target_in_a | /target_in_b`).

- With the fix: the test passes (and the earlier tree listing confirms the exact side-by-side row).
- Differential with `Comparison.py` reverted: the test fails — both columns print File A's target name, the reported behavior.
- Note: the repo needs Python ≥3.11; the pre-existing failures on this machine's run of the wider suite (cli/console tests that read stdin, and a golden CSV comparison) reproduce on `main` and are unrelated.


<!-- readthedocs-preview ncompare start -->
----
📚 Documentation preview 📚: https://ncompare--343.org.readthedocs.build/en/343/

<!-- readthedocs-preview ncompare end -->