### PR TITLE
Cleanup: remove dead code, de-duplicate variable-property computation, add license headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Common Changelog](https://common-changelog.org/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- Internal cleanup with no change to comparison output: remove dead code, compute each variable's scale factor and attributes once instead of twice, and add missing Apache license headers ([#347](https://github.com/nasa/ncompare/issues/347)) ([**@danielfromearth**](https://github.com/danielfromearth))
+
 ## [1.14.0] - 2025-12-30
 
 _Updates base Python version from 3.9 to 3.11._

--- a/ncompare/Comparison.py
+++ b/ncompare/Comparison.py
@@ -1,3 +1,30 @@
+# Copyright 2024 United States Government as represented by the Administrator of the
+# National Aeronautics and Space Administration. All Rights Reserved.
+#
+# This software calls the following third-party software,
+# which is subject to the terms and conditions of its licensor, as applicable.
+# Users must license their own copies; the links are provided for convenience only.
+#
+# colorama - BSD-3-Clause - https://opensource.org/licenses/BSD-3-Clause
+# netCDF4 - MIT License - https://opensource.org/licenses/MIT
+# numpy - BSD-3-Clause - https://opensource.org/licenses/BSD-3-Clause
+# openpyxl - MIT License - https://opensource.org/licenses/MIT
+# xarray - Apache License, version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
+# Python Standard Library - Python Software Foundation (PSF) License Agreement-
+#   https://docs.python.org/3/license.html#psf-license
+#
+# The ncompare: NetCDF structural comparison tool platform is licensed under the
+# Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+
+"""Traverse and compare the structure of two netCDF or HDF files."""
+
 from collections.abc import Iterator
 
 import h5py
@@ -196,6 +223,13 @@ class Comparison:
         v_b: VarProperties,
     ) -> None:
         """Align and display variable properties side by side."""
+        # Compute these once and reuse them below -- both when deciding whether to
+        # highlight the variable header and when printing each attribute row.
+        variable_attribute_pairs = (
+            list(get_and_check_variable_attributes(v_a, v_b)) if self.show_attributes else []
+        )
+        scale_factor_pair = get_and_check_variable_scale_factor(v_a, v_b)
+
         # Gather all variable property pairs first, before printing,
         # so we can decide whether to highlight the variable header.
         pairs_to_check_and_show = [
@@ -205,15 +239,8 @@ class Comparison:
         ]
         if self.show_chunks:
             pairs_to_check_and_show.append((v_a.chunking, v_b.chunking))
-        if self.show_attributes:
-            for attr_a_key, attr_a, attr_b_key, attr_b in get_and_check_variable_attributes(
-                v_a, v_b
-            ):
-                # Check whether attr_a_key is empty,
-                # because it might be if the variable doesn't exist in File A.
-                pairs_to_check_and_show.append((attr_a, attr_b))
-        # Scale Factor
-        scale_factor_pair = get_and_check_variable_scale_factor(v_a, v_b)
+        for _attr_a_key, attr_a, _attr_b_key, attr_b in variable_attribute_pairs:
+            pairs_to_check_and_show.append((attr_a, attr_b))
         if scale_factor_pair:
             pairs_to_check_and_show.append((scale_factor_pair[0], scale_factor_pair[1]))
 
@@ -251,18 +278,13 @@ class Comparison:
         if self.show_chunks:
             _var_attribute_side_by_side("chunksize", v_a.chunking, v_b.chunking)
         # Scale Factor
-        scale_factor_pair = get_and_check_variable_scale_factor(v_a, v_b)
         if scale_factor_pair:
             _var_attribute_side_by_side("scale_factor", scale_factor_pair[0], scale_factor_pair[1])
         # Other attributes
-        if self.show_attributes:
-            for attr_a_key, attr_a, attr_b_key, attr_b in get_and_check_variable_attributes(
-                v_a, v_b
-            ):
-                # Check whether attr_a_key is empty,
-                # because it might be if the variable doesn't exist in File A.
-                attribute_key = attr_a_key if attr_a_key else attr_b_key
-                _var_attribute_side_by_side(attribute_key, attr_a, attr_b)
+        for attr_a_key, attr_a, attr_b_key, attr_b in variable_attribute_pairs:
+            # attr_a_key may be empty if the variable doesn't exist in File A.
+            attribute_key = attr_a_key if attr_a_key else attr_b_key
+            _var_attribute_side_by_side(attribute_key, attr_a, attr_b)
 
     def _print_root_dimensions(self):
         # Show the dimensions of each file and evaluate differences.

--- a/ncompare/printing.py
+++ b/ncompare/printing.py
@@ -29,7 +29,7 @@
 import csv
 import re
 import warnings
-from collections.abc import Iterable, Iterator
+from collections.abc import Iterator
 from pathlib import Path
 from typing import TextIO
 
@@ -122,12 +122,9 @@ class Outputter:
         else:
             colorama.init(autoreset=True)
 
-        # Open a file
+        # Open a file (this overwrites any existing file at this path).
         if text_file:
             filepath = Path(text_file)
-            if filepath.exists():
-                pass
-            # This will overwrite any existing file at this path if one exists.
             self._text_file_obj: TextIO | None = open(filepath, "w", encoding="utf-8")  # pylint: disable=consider-using-with
         else:
             self._text_file_obj = None
@@ -185,24 +182,20 @@ class Outputter:
             # Remove any leading or trailing newlines.
             return result.strip("\n")
 
-        if isinstance(args, str):
-            parsed_strings = [_parse_single_str(args)]
-        elif isinstance(args, Iterable):
-            parsed_strings = []
-            for item in args:
-                if not isinstance(item, str):
-                    try:
-                        string = str(item)
-                    except Exception as err:
-                        raise TypeError(
-                            f"Error <{err}> with {str(item)}! Expected a string; got a <{type(item)}>."
-                        ) from err
-                else:
-                    string = item
+        # `args` is always a tuple (this method takes *args), so we iterate it directly.
+        parsed_strings = []
+        for item in args:
+            if not isinstance(item, str):
+                try:
+                    string = str(item)
+                except Exception as err:
+                    raise TypeError(
+                        f"Error <{err}> with {str(item)}! Expected a string; got a <{type(item)}>."
+                    ) from err
+            else:
+                string = item
 
-                parsed_strings.append(_parse_single_str(string))
-        else:
-            raise TypeError(f"Invalid type <{type(args)}>. Expected a `str` or `list`.")
+            parsed_strings.append(_parse_single_str(string))
 
         if self._keep_print_history:
             self._line_history.append(parsed_strings)

--- a/ncompare/utility_types.py
+++ b/ncompare/utility_types.py
@@ -1,3 +1,30 @@
+# Copyright 2024 United States Government as represented by the Administrator of the
+# National Aeronautics and Space Administration. All Rights Reserved.
+#
+# This software calls the following third-party software,
+# which is subject to the terms and conditions of its licensor, as applicable.
+# Users must license their own copies; the links are provided for convenience only.
+#
+# colorama - BSD-3-Clause - https://opensource.org/licenses/BSD-3-Clause
+# netCDF4 - MIT License - https://opensource.org/licenses/MIT
+# numpy - BSD-3-Clause - https://opensource.org/licenses/BSD-3-Clause
+# openpyxl - MIT License - https://opensource.org/licenses/MIT
+# xarray - Apache License, version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
+# Python Standard Library - Python Software Foundation (PSF) License Agreement-
+#   https://docs.python.org/3/license.html#psf-license
+#
+# The ncompare: NetCDF structural comparison tool platform is licensed under the
+# Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+
+"""Shared type definitions used across ncompare."""
+
 from collections import namedtuple
 from dataclasses import dataclass
 from pathlib import Path

--- a/tests/test_printing.py
+++ b/tests/test_printing.py
@@ -24,9 +24,20 @@
 # See the License for the specific language governing permissions and limitations under the License.
 
 
+from ncompare.printing import Outputter
+
+
 def test_list_of_strings_diff(outputter_to_console):
     left, right, shared = outputter_to_console.lists_diff(
         ["hey", "yo", "beebop"], ["what", "is", "this", "beebop"]
     )
 
     assert (left, right, shared) == (2, 3, 1)
+
+
+def test_add_to_history_records_one_row_with_ansi_and_newlines_stripped():
+    """A single call records one row; ANSI codes/newlines are stripped and non-strings coerced."""
+    out = Outputter(keep_print_history=True)
+    out._add_to_history("\x1b[31mred\x1b[0m", "plain\n", 42)
+
+    assert out._line_history == [["red", "plain", "42"]]


### PR DESCRIPTION
GitHub Issue: #347

### Description

Non-functional cleanups. **No change to comparison output** — the golden-file
tests pass unchanged.

- `printing.py`:
  - remove the no-op `if filepath.exists(): pass`;
  - remove the unreachable `isinstance(args, str)` branch (and trailing `else:
    raise`) in `_add_to_history` — `args` is always a tuple;
  - drop the now-unused `Iterable` import.
- `Comparison.py`: compute each variable's scale factor and attribute pairs once
  and reuse them, rather than recomputing for the header-highlight decision and
  again when printing each row.
- Add the Apache license header (and a one-line module docstring) to
  `Comparison.py` and `utility_types.py`, matching every other module.

### Local test steps

- `uv run pytest tests` → 26 passed, 2 deselected. The golden-file output test
  (`test_complete_file_output.py`) passing unchanged confirms identical output.
- Added `test_add_to_history_records_one_row_with_ansi_and_newlines_stripped`
  to lock in the simplified history-parsing behavior.
- `ruff check` clean.

### Overview of integration done

Unit-level only; no external services involved.

## PR Acceptance Checklist
* [x] Unit tests added/updated and passing.
* [ ] Integration testing
* [x] `CHANGELOG.md` updated
* [ ] Documentation updated (if needed).


<!-- readthedocs-preview ncompare start -->
----
📚 Documentation preview 📚: https://ncompare--348.org.readthedocs.build/en/348/

<!-- readthedocs-preview ncompare end -->