### PR TITLE
CI: run unit/integration tests on develop- and main-targeted PRs

### DIFF
--- a/.github/workflows/pull-request-received.yml
+++ b/.github/workflows/pull-request-received.yml
@@ -1,14 +1,17 @@
 name: Receive PR
 
-# read-only repo token
-# no access to secrets
+# Runs the test suite on pull requests. For same-repo PRs the Earthdata secrets
+# are available, so the integration tests run; PRs from forks have no secrets and
+# skip only the integration step (unit tests still run) -- see run_tests.yml.
 on:
   pull_request:
-    # Sequence of patterns matched against refs/heads
-    branches: [ feature/**, issue/**, issues/** ]
+    # Matched against the base branch (the branch the PR targets).
+    branches: [ develop, main, feature/**, issue/**, issues/** ]
 
 jobs:
   run_tests:
     uses: ./.github/workflows/run_tests.yml
     secrets:
       codecov_token: ${{ secrets.CODECOV_TOKEN }}
+      EARTHDATA_USERNAME: ${{ secrets.EARTHDATA_USERNAME }}
+      EARTHDATA_PASSWORD: ${{ secrets.EARTHDATA_PASSWORD }}

--- a/.github/workflows/pull-request-received.yml
+++ b/.github/workflows/pull-request-received.yml
@@ -1,8 +1,9 @@
 name: Receive PR
 
-# Runs the test suite on pull requests. For same-repo PRs the Earthdata secrets
-# are available, so the integration tests run; PRs from forks have no secrets and
-# skip only the integration step (unit tests still run) -- see run_tests.yml.
+# Runs the test suite on pull requests. Only `codecov_token` is passed -- the
+# Earthdata secrets are intentionally NOT exposed to PR-triggered runs, so the
+# integration tests are skipped on PRs while the unit tests still run. Integration
+# runs post-merge via version-and-build.yml, which provides the Earthdata secrets.
 on:
   pull_request:
     # Matched against the base branch (the branch the PR targets).
@@ -13,5 +14,3 @@ jobs:
     uses: ./.github/workflows/run_tests.yml
     secrets:
       codecov_token: ${{ secrets.CODECOV_TOKEN }}
-      EARTHDATA_USERNAME: ${{ secrets.EARTHDATA_USERNAME }}
-      EARTHDATA_PASSWORD: ${{ secrets.EARTHDATA_PASSWORD }}

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -21,11 +21,11 @@ on:
 jobs:
   build_and_test:
     runs-on: ubuntu-latest
-    # Exposed as env so the integration step can be skipped when unavailable
-    # (e.g., pull requests from forks, which have no access to secrets).
+    # A non-secret boolean recording whether Earthdata credentials were provided,
+    # used only to gate the integration step. The credential values themselves are
+    # set on that step alone (below), never job-wide.
     env:
-      EARTHDATA_USERNAME: ${{ secrets.EARTHDATA_USERNAME }}
-      EARTHDATA_PASSWORD: ${{ secrets.EARTHDATA_PASSWORD }}
+      HAS_EARTHDATA_CREDS: ${{ secrets.EARTHDATA_USERNAME != '' && secrets.EARTHDATA_PASSWORD != '' }}
     strategy:
       matrix:
         python-version: [ '3.11', '3.12', '3.13', '3.14' ]
@@ -59,9 +59,13 @@ jobs:
           uv run pytest -v -m "not integration" --cov=ncompare --cov-report=
 
       - name: Run integration tests with coverage
-        # Skipped when Earthdata credentials are unavailable (e.g., fork PRs);
-        # EARTHDATA_USERNAME/PASSWORD come from the job-level env above.
-        if: ${{ env.EARTHDATA_USERNAME != '' }}
+        # Runs only when Earthdata credentials are provided -- post-merge via
+        # version-and-build.yml. Skipped on pull requests (and forks), which do
+        # not receive the secrets. Credential values are scoped to this step.
+        if: ${{ env.HAS_EARTHDATA_CREDS == 'true' }}
+        env:
+          EARTHDATA_USERNAME: ${{ secrets.EARTHDATA_USERNAME }}
+          EARTHDATA_PASSWORD: ${{ secrets.EARTHDATA_PASSWORD }}
         run: |
           uv run pytest -v -m integration --cov=ncompare --cov-append --cov-report=
 

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -12,15 +12,20 @@ on:
         required: true
       EARTHDATA_USERNAME:
         description: 'NASA Earthdata username'
-        required: true
+        required: false
       EARTHDATA_PASSWORD:
         description: 'NASA Earthdata password'
-        required: true
+        required: false
   workflow_dispatch:
 
 jobs:
   build_and_test:
     runs-on: ubuntu-latest
+    # Exposed as env so the integration step can be skipped when unavailable
+    # (e.g., pull requests from forks, which have no access to secrets).
+    env:
+      EARTHDATA_USERNAME: ${{ secrets.EARTHDATA_USERNAME }}
+      EARTHDATA_PASSWORD: ${{ secrets.EARTHDATA_PASSWORD }}
     strategy:
       matrix:
         python-version: [ '3.11', '3.12', '3.13', '3.14' ]
@@ -54,9 +59,9 @@ jobs:
           uv run pytest -v -m "not integration" --cov=ncompare --cov-report=
 
       - name: Run integration tests with coverage
-        env:
-          EARTHDATA_USERNAME: ${{ secrets.EARTHDATA_USERNAME }}
-          EARTHDATA_PASSWORD: ${{ secrets.EARTHDATA_PASSWORD }}
+        # Skipped when Earthdata credentials are unavailable (e.g., fork PRs);
+        # EARTHDATA_USERNAME/PASSWORD come from the job-level env above.
+        if: ${{ env.EARTHDATA_USERNAME != '' }}
         run: |
           uv run pytest -v -m integration --cov=ncompare --cov-append --cov-report=
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Run the unit and integration test suite on pull requests targeting `develop` and `main` (previously only PRs based on `feature/**`/`issue/**` triggered tests), passing the Earthdata secrets through so integration runs; integration is skipped when credentials are unavailable (e.g., pull requests from forks) ([#355](https://github.com/nasa/ncompare/issues/355)) ([**@danielfromearth**](https://github.com/danielfromearth))
+
 ### Fixed
 
 - Resolve each variable's HDF5 object-reference attributes against its own file (File B was incorrectly dereferenced against File A), and use the correct parent-group name when building nested group paths during traversal ([#341](https://github.com/nasa/ncompare/issues/341)) ([**@danielfromearth**](https://github.com/danielfromearth))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Run the unit and integration test suite on pull requests targeting `develop` and `main` (previously only PRs based on `feature/**`/`issue/**` triggered tests), passing the Earthdata secrets through so integration runs; integration is skipped when credentials are unavailable (e.g., pull requests from forks) ([#355](https://github.com/nasa/ncompare/issues/355)) ([**@danielfromearth**](https://github.com/danielfromearth))
+- Run the unit test suite on pull requests targeting `develop` and `main` (previously only PRs based on `feature/**`/`issue/**` triggered tests). Integration tests, which require Earthdata credentials, are not run on pull requests and continue to run post-merge via `version-and-build.yml` ([#355](https://github.com/nasa/ncompare/issues/355)) ([**@danielfromearth**](https://github.com/danielfromearth))
 
 ### Fixed
 


### PR DESCRIPTION
GitHub Issue: #355

### Description

PRs targeting `develop` (the target prescribed in CONTRIBUTING) currently run **no** tests. `pull-request-received.yml` only ran `run_tests.yml` when the PR's base branch matched `feature/** | issue/** | issues/**`, so PRs into `develop`/`main` triggered nothing but pre-commit.ci / Snyk / RTD.

This makes the **unit** test suite run on `develop`- and `main`-targeted PRs. **Integration tests are intentionally kept off pull requests**: they require NASA Earthdata credentials, and we don't expose those secrets to PR-triggered runs (which execute contributor-controlled code). Integration continues to run **post-merge** via `version-and-build.yml` (push to `develop`/`main`), which already provides the secrets — so integration coverage isn't lost, just relocated to trusted commits.

### Changes

- `pull-request-received.yml`: add `develop` and `main` to the base-branch filter; pass **only** `codecov_token` (no Earthdata secrets), so PR runs never receive credentials.
- `run_tests.yml`: make the Earthdata secrets optional; gate the integration step on a **non-secret boolean** (`HAS_EARTHDATA_CREDS`) and scope the credential values to that step alone (not job-wide). PRs (no secrets) and forks (no secrets) therefore run unit tests only.

### Security note

No Earthdata credentials are passed to `pull_request`-triggered runs. This is `pull_request` (not `pull_request_target`), so PR code runs with a read-only token; forks never receive secrets. Integration + secrets remain confined to post-merge `push` runs.

### Local test steps

- Both workflow files validated as YAML. No application code changed.
- Behavior confirmed by CI on this PR: unit tests run; the integration step is skipped (no credentials).

## PR Acceptance Checklist
* [x] Unit tests added/updated and passing. _(n/a — CI config; existing suite unaffected)_
* [ ] Integration testing
* [x] `CHANGELOG.md` updated
* [ ] Documentation updated (if needed).

---
_Note: this PR's own checks remain red until #357 merges — the failing check is the
pre-existing `test_hdf5_references` unit test (from #342), unrelated to this PR's
workflow changes._
