### PR TITLE
Bug: read HDF5 root dimensions via h5py so non-netCDF4 files don't crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Resolve each variable's HDF5 object-reference attributes against its own file (File B was incorrectly dereferenced against File A), and use the correct parent-group name when building nested group paths during traversal ([#341](https://github.com/nasa/ncompare/issues/341)) ([**@danielfromearth**](https://github.com/danielfromearth))
+- Read HDF5 root-level dimensions via h5py dimension scales and degrade gracefully when they can't be introspected, so `ncompare` no longer crashes on non-netCDF4 HDF5 files ([#357](https://github.com/nasa/ncompare/issues/357)) ([**@danielfromearth**](https://github.com/danielfromearth))
 
 ## [1.14.0] - 2025-12-30
 

--- a/ncompare/Comparison.py
+++ b/ncompare/Comparison.py
@@ -432,7 +432,13 @@ class Comparison:
                 v_dimensions = str(the_variable.dimensions)
             elif self.file_types == "hdf5":
                 dim_list: list[str] = []
-                for dim in the_variable.dims:
+                # Accessing `.dims` can raise on HDF5 files whose dimension scales
+                # can't be introspected; treat those as having no dimensions.
+                try:
+                    variable_dims = list(the_variable.dims)
+                except RuntimeError:
+                    variable_dims = []
+                for dim in variable_dims:
                     try:
                         dim_list.append(dim.label)
                     except RuntimeError:

--- a/ncompare/getters.py
+++ b/ncompare/getters.py
@@ -97,27 +97,51 @@ def get_variables(node: netCDF4.Dataset | netCDF4.Group | h5py.Group, file_type:
 
 
 def get_root_dims(file: FileToCompare) -> list:
-    """Get a list of dimensions from a netCDF or HDF5."""
+    """Get a list of root-level dimensions from a netCDF or HDF5 file."""
+    if file.type == "hdf5":
+        return _get_hdf5_root_dims(file.path)
+    return _get_netcdf_root_dims(file.path)
+
+
+def _get_netcdf_root_dims(path) -> list:
+    """Get a list of root-level dimensions from a netCDF file (via xarray)."""
 
     def __get_dim_list(decode_times=True):
         with warnings.catch_warnings():
             warnings.simplefilter("ignore")
-            if file.type == "netcdf":
-                xarray_engine = "netcdf4"
-            elif file.type == "hdf5":
-                xarray_engine = "h5netcdf"
-
-            with xr.open_dataset(
-                file.path, decode_times=decode_times, engine=xarray_engine
-            ) as dataset:
+            with xr.open_dataset(path, decode_times=decode_times, engine="netcdf4") as dataset:
                 return list(dataset.sizes.items())
 
     try:
-        dims_list = __get_dim_list()
+        return __get_dim_list()
     except ValueError as err:
         if "decode_times" in str(err):  # then try again without decoding the times
-            dims_list = __get_dim_list(decode_times=False)
-        else:
-            raise err from None  # "from None" prevents additional trace (see https://stackoverflow.com/a/18188660)
+            return __get_dim_list(decode_times=False)
+        raise err from None  # "from None" prevents additional trace (see https://stackoverflow.com/a/18188660)
 
-    return dims_list
+
+def _get_hdf5_root_dims(path) -> list:
+    """Get a list of root-level dimensions from an HDF5 file (via h5py).
+
+    HDF5 has no netCDF-style named dimensions; they are represented by optional
+    HDF5 dimension scales. Files with dimension scales -- including netCDF4 files,
+    which are a subset of HDF5 -- report those; a pure HDF5 file with none reports
+    no root-level dimensions rather than raising, so the rest of the structural
+    comparison can still proceed.
+    """
+    dims: list[tuple[str, int]] = []
+    try:
+        with h5py.File(path, "r") as dataset:
+            for name, obj in dataset.items():
+                if not isinstance(obj, h5py.Dataset):
+                    continue
+                class_attr = obj.attrs.get("CLASS")
+                if isinstance(class_attr, bytes):
+                    class_attr = class_attr.decode("utf-8", errors="replace")
+                if class_attr == "DIMENSION_SCALE":
+                    size = obj.shape[0] if obj.shape else obj.size
+                    dims.append((name, int(size)))
+    except (OSError, RuntimeError, KeyError):
+        # Some HDF5 files cannot be introspected for dimensions; degrade gracefully.
+        return []
+    return sorted(dims)

--- a/tests/test_getters.py
+++ b/tests/test_getters.py
@@ -1,3 +1,31 @@
+import h5py
+import numpy as np
+
+from ncompare.getters import get_root_dims
+from ncompare.utility_types import FileToCompare
+
+
+def test_get_root_dims_pure_hdf5_without_dimension_scales(tmp_path):
+    """A pure HDF5 file with no dimension scales reports no root dimensions (no crash)."""
+    path = tmp_path / "pure.h5"
+    with h5py.File(path, "w") as f:
+        f.create_dataset("data", data=np.arange(4))
+
+    assert get_root_dims(FileToCompare(path=path, type="hdf5")) == []
+
+
+def test_get_root_dims_hdf5_with_dimension_scale(tmp_path):
+    """Root dimensions are recovered from HDF5 dimension scales when present."""
+    path = tmp_path / "scaled.h5"
+    with h5py.File(path, "w") as f:
+        scale = f.create_dataset("x", data=np.arange(5))
+        scale.make_scale("x")
+        data = f.create_dataset("data", data=np.zeros(5))
+        data.dims[0].attach_scale(scale)
+
+    assert get_root_dims(FileToCompare(path=path, type="hdf5")) == [("x", 5)]
+
+
 # def test_var_properties(ds_3dims_3vars_4coords_1group):
 #     with nc.Dataset(ds_3dims_3vars_4coords_1group) as ds:
 #         result = get_var_properties(ds.groups["Group1"], varname="step", file_type="netcdf")

--- a/tests/test_getters.py
+++ b/tests/test_getters.py
@@ -1,4 +1,5 @@
 import h5py
+import netCDF4
 import numpy as np
 
 from ncompare.getters import get_root_dims
@@ -15,15 +16,19 @@ def test_get_root_dims_pure_hdf5_without_dimension_scales(tmp_path):
 
 
 def test_get_root_dims_hdf5_with_dimension_scale(tmp_path):
-    """Root dimensions are recovered from HDF5 dimension scales when present."""
-    path = tmp_path / "scaled.h5"
-    with h5py.File(path, "w") as f:
-        scale = f.create_dataset("x", data=np.arange(5))
-        scale.make_scale("x")
-        data = f.create_dataset("data", data=np.zeros(5))
-        data.dims[0].attach_scale(scale)
+    """Root dimensions are recovered from HDF5 dimension scales when present.
 
-    assert get_root_dims(FileToCompare(path=path, type="hdf5")) == [("x", 5)]
+    Authored with netCDF4 (a coordinate variable is stored as an HDF5 dimension
+    scale) so the scale is created portably; the file is then read via the h5py
+    path in get_root_dims.
+    """
+    path = tmp_path / "scaled.h5"
+    with netCDF4.Dataset(path, "w") as ds:
+        ds.createDimension("x", 5)
+        coordinate = ds.createVariable("x", "f4", ("x",))
+        coordinate[:] = range(5)
+
+    assert ("x", 5) in get_root_dims(FileToCompare(path=path, type="hdf5"))
 
 
 # def test_var_properties(ds_3dims_3vars_4coords_1group):


### PR DESCRIPTION
GitHub Issue: #357

### Description

Reading the root-level dimensions of a **non-netCDF4 HDF5** file could crash. `get_root_dims` opened HDF5 files with xarray's `h5netcdf` engine, which assumes netCDF4 conventions (dimension scales); a pure HDF5 file without them trips the HDF5 library:

```
RuntimeError: Unspecified error in H5DSget_num_scales (return value <0)
```

This surfaced via the pure-HDF5 regression test added in #342 (`tests/test_hdf5_references.py`): it passed on macOS but failed on the Linux CI runners — and, because PR CI wasn't running on develop-targeted PRs (fixed in #355/#356), it merged unnoticed, turning `develop` red. Since netCDF4 is a subset of HDF5, `ncompare` should handle general HDF5 files for structural comparison rather than crash.

### Changes

- `get_root_dims`: for HDF5, read root dimensions from **h5py dimension scales** (recovers real dimensions when present, e.g. netCDF4-as-HDF5), and **degrade gracefully to no dimensions** for pure HDF5 that has none — instead of raising. (netCDF path unchanged.)
- `Comparison._create_var_properties`: guard the `the_variable.dims` iteration against the same `RuntimeError`.
- Kept the pure-HDF5 test fixture (that's the point of the test).

### Local test steps

- `uv run pytest -m "not integration"` → 28 passed. `ruff` clean.
- Added `tests/test_getters.py` cases: pure HDF5 with no dimension scales → no dims; HDF5 with a dimension scale → the dim is recovered.
- **ICESat-2 ATL06 integration count unchanged (5280)**, verified locally — moving HDF5 dims off h5netcdf doesn't alter real-file results.
- Linux CI on this PR runs unit tests (integration is skipped on PRs per #356); this should now be green, confirming the Linux-only crash is resolved.

### Overview of integration done

Structural comparison of synthetic HDF5 fixtures + ATL06 granules locally; full integration runs post-merge via `version-and-build.yml`.

## PR Acceptance Checklist
* [x] Unit tests added/updated and passing.
* [x] Integration testing _(ATL06 verified locally; count unchanged)_
* [x] `CHANGELOG.md` updated
* [ ] Documentation updated (if needed).

---
_Merging this turns `develop` green again (it fixes the `test_hdf5_references`
failure introduced by #342)._


<!-- readthedocs-preview ncompare start -->
----
📚 Documentation preview 📚: https://ncompare--358.org.readthedocs.build/en/358/

<!-- readthedocs-preview ncompare end -->