### PR TITLE
test: pin ATL06 version so the integration diff count is reproducible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Resolve each variable's HDF5 object-reference attributes against its own file (File B was incorrectly dereferenced against File A), and use the correct parent-group name when building nested group paths during traversal ([#341](https://github.com/nasa/ncompare/issues/341)) ([**@danielfromearth**](https://github.com/danielfromearth))
 - Read HDF5 root-level dimensions via h5py dimension scales and degrade gracefully when they can't be introspected, so `ncompare` no longer crashes on non-netCDF4 HDF5 files ([#357](https://github.com/nasa/ncompare/issues/357)) ([**@danielfromearth**](https://github.com/danielfromearth))
+- Pin the ATL06 granule version in the integration test so its difference count is reproducible; NASA reprocessed ATL06 (006 → 007), which had changed the count and broken CI ([#359](https://github.com/nasa/ncompare/issues/359)) ([**@danielfromearth**](https://github.com/danielfromearth))
 
 ## [1.14.0] - 2025-12-30
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -62,20 +62,29 @@ def earthdata_auth():
     return True
 
 
+# Pin the ATL06 version so the comparison -- and its difference count -- is
+# reproducible. ATL06 is periodically reprocessed (e.g., 006 -> 007), which changes
+# the data and would otherwise change the expected count in test_icesat.
+ATL06_VERSION = "007"
+
+
 @pytest.fixture(scope="session")
 def icesat2_atl06_granule_1(icesat2_cache_dir, earthdata_auth):
     """
     Download or use cached ICESat-2 ATL06 granule #1 for comparison tests.
     Temporal range: 2023-08-16 16:16:15 to 2023-08-16 16:25:00
     """
-    # Check if already cached
-    cached_files = list(icesat2_cache_dir.glob("ATL06_20230816161508_*.h5"))
+    # Check if already cached (version-specific, so a stale version isn't reused)
+    cached_files = list(icesat2_cache_dir.glob(f"ATL06_20230816161508_*_{ATL06_VERSION}_*.h5"))
     if cached_files:
         return str(cached_files[0])
 
     # Download if not cached
     results = earthaccess.search_data(
-        short_name="ATL06", temporal=("2023-08-16 16:16:15", "2023-08-16 16:25:00"), count=1
+        short_name="ATL06",
+        version=ATL06_VERSION,
+        temporal=("2023-08-16 16:16:15", "2023-08-16 16:25:00"),
+        count=1,
     )
 
     if not results:
@@ -96,14 +105,17 @@ def icesat2_atl06_granule_2(icesat2_cache_dir, earthdata_auth):
     Download or use cached ICESat-2 ATL06 granule #2 for comparison tests.
     Temporal range: 2023-08-16 23:46:00 to 2023-08-16 23:48:00
     """
-    # Check if already cached
-    cached_files = list(icesat2_cache_dir.glob("ATL06_20230816234629_*.h5"))
+    # Check if already cached (version-specific, so a stale version isn't reused)
+    cached_files = list(icesat2_cache_dir.glob(f"ATL06_20230816234629_*_{ATL06_VERSION}_*.h5"))
     if cached_files:
         return str(cached_files[0])
 
     # Download if not cached
     results = earthaccess.search_data(
-        short_name="ATL06", temporal=("2023-08-16 23:46:00", "2023-08-16 23:48:00"), count=1
+        short_name="ATL06",
+        version=ATL06_VERSION,
+        temporal=("2023-08-16 23:46:00", "2023-08-16 23:48:00"),
+        count=1,
     )
 
     if not results:

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -91,7 +91,9 @@ def test_icesat(temp_data_dir, icesat2_atl06_granule_1, icesat2_atl06_granule_2)
     assert num_differences > 0, "Expected to find differences between granules"
     assert out_path.exists(), "Output file was not created"
 
-    assert num_differences == 5280
+    # Exact count for the pinned ATL06 version (see ATL06_VERSION in conftest.py).
+    # Update this if that version is changed; ATL06 reprocessing changes the data.
+    assert num_differences == 4958
 
 
 @pytest.mark.integration


### PR DESCRIPTION
GitHub Issue: #359

### Description

`test_icesat` asserted an exact difference count (`== 5280`), but the granule fixtures fetched data with an **unpinned** `search_data(short_name="ATL06", ... count=1)`. NASA reprocessed ATL06 (`006` → `007`), so the search started returning the newer version and the count changed (`5280` → `4958`), turning `develop` CI red — with **no code change** responsible. (Root-caused via a temporary diagnostic: on both macOS and Linux `dims_errors=0` and root dims are uncounted; the only difference was the granule version — `006_02` locally vs `007_01` on CI.)

### Changes

- `conftest.py`: pin `ATL06_VERSION = "007"` in both granule fixtures (`search_data(version=...)`), and make the cache glob **version-specific** (`ATL06_..._007_*.h5`) so a stale cached version isn't silently reused.
- `test_core.py`: recalibrate the expected count to **4958** — verified identical on macOS and Linux for the pinned version — while keeping the `num_differences > 0` and output-file assertions.

### Local test steps

- With the pinned fixture, the stale local v006 cache is bypassed; v007 is downloaded and `test_icesat` passes (`4958`). Confirmed the same count on Linux CI via a dispatched `run_tests.yml` run.
- `uv run pytest` (unit) → 28 passed; `ruff` clean.

### Note

The integration test is skipped on PR CI (unit-only, per #355), so this PR's own checks won't exercise `test_icesat`; it runs post-merge via `version-and-build.yml` (and I validated it via a manual `run_tests.yml` dispatch on this branch).

## PR Acceptance Checklist
* [x] Unit tests added/updated and passing.
* [x] Integration testing _(validated via dispatched run_tests.yml on this branch)_
* [x] `CHANGELOG.md` updated
* [ ] Documentation updated (if needed).


<!-- readthedocs-preview ncompare start -->
----
📚 Documentation preview 📚: https://ncompare--360.org.readthedocs.build/en/360/

<!-- readthedocs-preview ncompare end -->