### PR TITLE
Fix CLI failing on netCDF files on Linux (h5py/netCDF4 HDF5 load order)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fix the command line failing on netCDF files on Linux with "[Errno -101] NetCDF: HDF error". `h5py` and `netCDF4` each bundle their own copy of the HDF5 library and only the first loaded is used, so `netCDF4` is now imported first ([#363](https://github.com/nasa/ncompare/issues/363)) ([**@danielfromearth**](https://github.com/danielfromearth))
 - Resolve each variable's HDF5 object-reference attributes against its own file (File B was incorrectly dereferenced against File A), and use the correct parent-group name when building nested group paths during traversal ([#341](https://github.com/nasa/ncompare/issues/341)) ([**@danielfromearth**](https://github.com/danielfromearth))
 - Read HDF5 root-level dimensions via h5py dimension scales and degrade gracefully when they can't be introspected, so `ncompare` no longer crashes on non-netCDF4 HDF5 files ([#357](https://github.com/nasa/ncompare/issues/357)) ([**@danielfromearth**](https://github.com/danielfromearth))
 - Pin the ATL06 granule version in the integration test so its difference count is reproducible; NASA reprocessed ATL06 (006 → 007), which had changed the count and broken CI ([#359](https://github.com/nasa/ncompare/issues/359)) ([**@danielfromearth**](https://github.com/danielfromearth))

--- a/ncompare/__init__.py
+++ b/ncompare/__init__.py
@@ -27,6 +27,22 @@
 
 from importlib.metadata import version
 
+# `netCDF4` must be imported before `h5py`. Both distribute wheels that bundle
+# their own copy of the HDF5 library, and only the first one loaded is used. When
+# `h5py` wins that race, `netCDF4` can no longer open valid netCDF4 files on
+# Linux, failing with "[Errno -101] NetCDF: HDF error". See
+# https://github.com/Unidata/netcdf4-python/issues/653 and
+# https://github.com/Unidata/netcdf4-python/issues/1343; importing `netCDF4`
+# first is the accepted workaround.
+#
+# Importing it here fixes the order for every entry point, because Python runs
+# this module before any `ncompare` submodule. It cannot be fixed by reordering
+# the imports inside those submodules: `h5py` sorts before `netCDF4`
+# alphabetically, so the linter would just put it back.
+#
+# tests/test_import_order.py guards this.
+import netCDF4  # noqa: F401  # imported first for its side effect on load order
+
 from .core import (
     compare,
 )

--- a/tests/test_import_order.py
+++ b/tests/test_import_order.py
@@ -1,0 +1,76 @@
+# Copyright 2024 United States Government as represented by the Administrator of the
+# National Aeronautics and Space Administration. All Rights Reserved.
+#
+# This software calls the following third-party software,
+# which is subject to the terms and conditions of its licensor, as applicable.
+# Users must license their own copies; the links are provided for convenience only.
+#
+# netCDF4 - MIT License - https://opensource.org/licenses/MIT
+# xarray - Apache License, version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
+# Python Standard Library - Python Software Foundation (PSF) License Agreement-
+#   https://docs.python.org/3/license.html#psf-license
+#
+# The ncompare: NetCDF structural comparison tool platform is licensed under the
+# Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+
+"""Tests that `ncompare` can still read netCDF files after it has been imported.
+
+`h5py` and `netCDF4` each bundle their own copy of the HDF5 library, and only the
+first one loaded is used. If `h5py` loads first, `netCDF4` can no longer open
+valid netCDF4 files. `ncompare/__init__.py` imports `netCDF4` first to prevent
+that; these tests are what keep it there.
+
+Every test here runs in a **fresh interpreter**, deliberately. Importing `netCDF4`
+anywhere earlier in the process fixes the load order, and `tests/conftest.py` does
+exactly that -- so an in-process version of these tests would pass whether or not
+the fix is present, and would guard nothing.
+"""
+
+import subprocess
+import sys
+
+from . import data_for_tests_dir
+
+FILE_A = str(data_for_tests_dir / "test_a.nc")
+FILE_B = str(data_for_tests_dir / "test_b.nc")
+
+
+def _run_in_fresh_interpreter(code: str) -> subprocess.CompletedProcess:
+    return subprocess.run([sys.executable, "-c", code], capture_output=True, text=True)
+
+
+def test_netcdf_is_readable_after_importing_ncompare():
+    """Importing `ncompare` must not break netCDF4's ability to open a file."""
+    result = _run_in_fresh_interpreter(
+        "import ncompare\n"
+        "import xarray as xr\n"
+        f"with xr.open_dataset(r'{FILE_A}', engine='netcdf4') as dataset:\n"
+        "    print(sorted(dataset.sizes))\n"
+    )
+    assert result.returncode == 0, (
+        f"Reading a netCDF file failed after importing ncompare.\n{result.stderr}"
+    )
+    assert "conditions" in result.stdout
+
+
+def test_compare_works_in_a_fresh_interpreter():
+    """`compare()` must work as the first thing a process does, as it does via the CLI."""
+    result = _run_in_fresh_interpreter(
+        f"from ncompare.core import compare\nprint(compare(r'{FILE_A}', r'{FILE_B}'))\n"
+    )
+    assert result.returncode == 0, f"compare() failed in a fresh interpreter.\n{result.stderr}"
+
+
+def test_cli_compares_netcdf_files():
+    """End-to-end guard on the CLI, the path that was broken on Linux (see #363)."""
+    result = subprocess.run(["ncompare", FILE_A, FILE_B], capture_output=True, text=True)
+    assert result.returncode == 0, (
+        f"The ncompare CLI failed on netCDF input.\n{result.stdout}\n{result.stderr}"
+    )


### PR DESCRIPTION
GitHub Issue: #363

### Description

Running `ncompare` from the command line on Linux fails on valid netCDF4 files with
`OSError: [Errno -101] NetCDF: HDF error`, raised while reading root-level dimensions. This affects
the CLI — the tool's primary interface — reproducibly, on all four supported Python versions.

`h5py` and `netCDF4` each ship wheels bundling their own copy of the HDF5 library, and only the first
one loaded is used. When `h5py` loads first, `netCDF4` can no longer open valid netCDF4 files.
Verified on a Linux runner:

| Imports | Result |
| --- | --- |
| `xarray` only | works |
| `h5py` → `xarray` | **fails** |
| `h5py` → `netCDF4` → `xarray` | **fails** |
| `netCDF4` → `h5py` → `xarray` | works |
| `import ncompare.core` → `xarray` | **fails** |

Both report HDF5 `1.14.6` — the version strings match, the copies do not. Importing `netCDF4` first
is the accepted upstream workaround ([netcdf4-python#653](https://github.com/Unidata/netcdf4-python/issues/653):
*"Workaround: If netCDF4 is imported first, there is no error and everything works fine!"*, and
[#1343](https://github.com/Unidata/netcdf4-python/issues/1343)). Another project applies the same fix
in [python-tristan#119](https://github.com/DiamondLightSource/python-tristan/pull/119).

### Changes

- Import `netCDF4` in `ncompare/__init__.py`, ahead of the submodule imports.
- Add `tests/test_import_order.py` — three regression tests, all in fresh interpreters.

`Comparison.py` and `getters.py` both import `h5py` before `netCDF4`, not by choice but because `h5py`
sorts first alphabetically and `"I"` (isort) is an enabled ruff rule — I confirmed ruff flags the
reverse order as a fixable error. So reordering imports inside those modules is not durable; the
linter puts them back. Fixing the order once in the package `__init__` covers every entry point,
because Python runs it before any submodule, and that position *is* isort-stable.

### Why no test caught this

The bug was masked in both directions:

1. `tests/conftest.py` does `import netCDF4 as nC`, which fixes the load order for the entire pytest
   session — so every in-process test was accidentally protected.
2. No test ran the CLI against real data files. `test_console_version` and `test_console_help` only
   pass `--version`/`--help`, which never open anything.

That is why the new tests run in **fresh interpreters**. An in-process version would pass with or
without the fix and would guard nothing — I verified this reasoning against the observed behavior
rather than assuming it.

It surfaced only when a subprocess CLI test was added in #354, whose CI is red because of this bug,
not because of anything in that PR (its failing assertion does not even use `--exit-code`).

### Local test steps

- `pytest -m "not integration"` → 34 passed, 1 deselected. `ruff check` / `ruff format` clean.
- The three new tests pass locally, but **cannot fail on macOS** — the bug is Linux-only. Their
  failing behavior was established empirically on Linux runners before the fix, and the fix was
  verified on a Linux runner after: `import ncompare` → `xr.open` ✅, fresh-interpreter `compare()` ✅
  (`26`), CLI subprocess ✅ (`26`). Linux CI on this PR is the real check.

### Overview of integration done

Diagnosed and verified across four dispatched Linux CI runs, narrowing from "test file won't open" to
the import-order race. Two earlier hypotheses were tested and disproved along the way — a git-LFS
pointer (the committed file is genuine HDF5) and concurrent double-open of the same file (five
open-ordering permutations all passed).

## PR Acceptance Checklist
* [x] Unit tests added/updated and passing.
* [x] Integration testing _(verified on Linux runners before and after the fix; see above)_
* [x] `CHANGELOG.md` updated
* [ ] Documentation updated (if needed) — _no user-facing docs change; the rationale is documented in code and in #363_


<!-- readthedocs-preview ncompare start -->
----
📚 Documentation preview 📚: https://ncompare--364.org.readthedocs.build/en/364/

<!-- readthedocs-preview ncompare end -->