### PR TITLE
Give each summary tally its own difference types set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Give each summary tally its own `difference_types` set instead of sharing one via a shallow copy ([#365](https://github.com/nasa/ncompare/issues/365)) ([**@Hashim1999164**](https://github.com/Hashim1999164))
+
 ### Changed
 
 - Run the unit test suite on pull requests targeting `develop` and `main` (previously only PRs based on `feature/**`/`issue/**` triggered tests). Integration tests, which require Earthdata credentials, are not run on pull requests and continue to run post-merge via `version-and-build.yml` ([#355](https://github.com/nasa/ncompare/issues/355)) ([**@danielfromearth**](https://github.com/danielfromearth))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Fixed
-
-- Give each summary tally its own `difference_types` set instead of sharing one via a shallow copy ([#365](https://github.com/nasa/ncompare/issues/365)) ([**@Hashim1999164**](https://github.com/Hashim1999164))
-
 ### Changed
 
 - Run the unit test suite on pull requests targeting `develop` and `main` (previously only PRs based on `feature/**`/`issue/**` triggered tests). Integration tests, which require Earthdata credentials, are not run on pull requests and continue to run post-merge via `version-and-build.yml` ([#355](https://github.com/nasa/ncompare/issues/355)) ([**@danielfromearth**](https://github.com/danielfromearth))
@@ -27,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Give each summary tally its own `difference_types` set instead of sharing one via a shallow copy ([#365](https://github.com/nasa/ncompare/issues/365)) ([**@Hashim1999164**](https://github.com/Hashim1999164))
 - Fix the command line failing on netCDF files on Linux with "[Errno -101] NetCDF: HDF error". `h5py` and `netCDF4` each bundle their own copy of the HDF5 library and only the first loaded is used, so `netCDF4` is now imported first ([#363](https://github.com/nasa/ncompare/issues/363)) ([**@danielfromearth**](https://github.com/danielfromearth))
 - Resolve each variable's HDF5 object-reference attributes against its own file (File B was incorrectly dereferenced against File A), and use the correct parent-group name when building nested group paths during traversal ([#341](https://github.com/nasa/ncompare/issues/341)) ([**@danielfromearth**](https://github.com/danielfromearth))
 - Restore colorama's global color state after a no-color comparison, so `no_color=True` no longer permanently disables color for later comparisons or other libraries in the same process ([#345](https://github.com/nasa/ncompare/issues/345)) ([**@danielfromearth**](https://github.com/danielfromearth))

--- a/ncompare/Comparison.py
+++ b/ncompare/Comparison.py
@@ -52,7 +52,6 @@ from ncompare.utility_types import (
 )
 
 
-
 def _blank_difference_dict() -> SummaryDifferencesDict:
     """Return a fresh summary tally so nested sets are not shared across tallies."""
     return {

--- a/ncompare/Comparison.py
+++ b/ncompare/Comparison.py
@@ -52,6 +52,18 @@ from ncompare.utility_types import (
 )
 
 
+
+def _blank_difference_dict() -> SummaryDifferencesDict:
+    """Return a fresh summary tally so nested sets are not shared across tallies."""
+    return {
+        "shared": 0,
+        "left": 0,
+        "right": 0,
+        "both": 0,
+        "difference_types": set(),
+    }
+
+
 class Comparison:
     def __init__(
         self,
@@ -72,16 +84,9 @@ class Comparison:
         self.show_chunks: bool = show_chunks
         self.show_attributes: bool = show_attributes
 
-        blank_difference_dict: SummaryDifferencesDict = {
-            "shared": 0,
-            "left": 0,
-            "right": 0,
-            "both": 0,
-            "difference_types": set(),
-        }
-        self.num_group_diffs: SummaryDifferencesDict = blank_difference_dict.copy()
-        self.num_var_diffs: SummaryDifferencesDict = blank_difference_dict.copy()
-        self.num_attribute_diffs: SummaryDifferencesDict = blank_difference_dict.copy()
+        self.num_group_diffs: SummaryDifferencesDict = _blank_difference_dict()
+        self.num_var_diffs: SummaryDifferencesDict = _blank_difference_dict()
+        self.num_attribute_diffs: SummaryDifferencesDict = _blank_difference_dict()
 
         self.open_file1 = None
         self.open_file2 = None

--- a/tests/test_comparison.py
+++ b/tests/test_comparison.py
@@ -108,9 +108,9 @@ def test_variable_name_truncated_to_configured_column_width(tmp_path):
     assert all(long_name not in cell for row in out._line_history for cell in row)
 
 
-def test_summary_tally_difference_types_are_independent():
+def test_summary_tally_difference_types_are_independent(tmp_path):
     """Each summary tally keeps its own difference_types set."""
-    file = FileToCompare(path="a.nc", type="netcdf")
+    file = FileToCompare(path=tmp_path / "a.nc", type="netcdf")
     with Outputter() as out:
         comparison = Comparison(file, file, out, show_chunks=False, show_attributes=False)
 

--- a/tests/test_comparison.py
+++ b/tests/test_comparison.py
@@ -107,6 +107,7 @@ def test_variable_name_truncated_to_configured_column_width(tmp_path):
     assert variable_rows[0][1] == long_name[:12]
     assert all(long_name not in cell for row in out._line_history for cell in row)
 
+
 def test_summary_tally_difference_types_are_independent():
     """Each summary tally keeps its own difference_types set."""
     file = FileToCompare(path="a.nc", type="netcdf")
@@ -116,4 +117,3 @@ def test_summary_tally_difference_types_are_independent():
     comparison.num_attribute_diffs["difference_types"].add("units")
     assert comparison.num_var_diffs["difference_types"] == set()
     assert comparison.num_group_diffs["difference_types"] == set()
-

--- a/tests/test_comparison.py
+++ b/tests/test_comparison.py
@@ -106,3 +106,14 @@ def test_variable_name_truncated_to_configured_column_width(tmp_path):
     # The name is truncated to the configured width (12), never the full 80 characters.
     assert variable_rows[0][1] == long_name[:12]
     assert all(long_name not in cell for row in out._line_history for cell in row)
+
+def test_summary_tally_difference_types_are_independent():
+    """Each summary tally keeps its own difference_types set."""
+    file = FileToCompare(path="a.nc", type="netcdf")
+    with Outputter() as out:
+        comparison = Comparison(file, file, out, show_chunks=False, show_attributes=False)
+
+    comparison.num_attribute_diffs["difference_types"].add("units")
+    assert comparison.num_var_diffs["difference_types"] == set()
+    assert comparison.num_group_diffs["difference_types"] == set()
+


### PR DESCRIPTION
Closes #365

The three summary tally dictionaries were copied from one template with dict.copy, so they shared a single difference_types set. Each tally now comes from a small factory that builds a new dictionary and a new set.