### PR TITLE
Fix HDF5 variable attributes displayed as byte reprs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Decode fixed-length HDF5 variable attribute strings before comparison and display, including string arrays, while preserving object-reference handling ([#370](https://github.com/nasa/ncompare/issues/370)).
+
 - Fix the command line failing on netCDF files on Linux with "[Errno -101] NetCDF: HDF error". `h5py` and `netCDF4` each bundle their own copy of the HDF5 library and only the first loaded is used, so `netCDF4` is now imported first ([#363](https://github.com/nasa/ncompare/issues/363)) ([**@danielfromearth**](https://github.com/danielfromearth))
 - Resolve each variable's HDF5 object-reference attributes against its own file (File B was incorrectly dereferenced against File A), and use the correct parent-group name when building nested group paths during traversal ([#341](https://github.com/nasa/ncompare/issues/341)) ([**@danielfromearth**](https://github.com/danielfromearth))
 - Restore colorama's global color state after a no-color comparison, so `no_color=True` no longer permanently disables color for later comparisons or other libraries in the same process ([#345](https://github.com/nasa/ncompare/issues/345)) ([**@danielfromearth**](https://github.com/danielfromearth))

--- a/ncompare/Comparison.py
+++ b/ncompare/Comparison.py
@@ -33,6 +33,7 @@ import numpy as np
 from colorama import Fore
 
 from ncompare.getters import (
+    _value_to_comparable_str,
     get_and_check_variable_attributes,
     get_and_check_variable_scale_factor,
     get_root_attributes,
@@ -549,7 +550,17 @@ class Comparison:
                 for name in the_variable.attrs.keys():
                     attribute_value = the_variable.attrs[name]
                     if isinstance(attribute_value, np.ndarray):
-                        if attribute_value.dtype == h5py.ref_dtype:
+                        if h5py.check_string_dtype(attribute_value.dtype) is not None:
+                            # Decode text before formatting, without treating vlen
+                            # strings (object dtype) as object-reference arrays.
+                            if attribute_value.dtype.kind == "S":
+                                attribute_value = np.char.decode(
+                                    attribute_value, "utf-8", errors="replace"
+                                )
+                            else:
+                                attribute_value = attribute_value.astype(str)
+                            retrieved_value = str(attribute_value)
+                        elif attribute_value.dtype == h5py.ref_dtype:
                             retrieved_value = __name_from_h5_ref(attribute_value[0][0])
                         else:
                             try:
@@ -560,7 +571,7 @@ class Comparison:
                                 retrieved_value = str(attribute_value)
 
                     else:
-                        retrieved_value = str(attribute_value)
+                        retrieved_value = _value_to_comparable_str(attribute_value)
 
                     v_attributes[name] = retrieved_value
         else:

--- a/tests/test_hdf5_references.py
+++ b/tests/test_hdf5_references.py
@@ -30,6 +30,7 @@ import numpy as np
 import pytest
 
 from ncompare.Comparison import Comparison
+from ncompare.core import compare
 from ncompare.printing import Outputter
 from ncompare.utility_types import FileToCompare
 
@@ -77,3 +78,72 @@ def test_hdf5_reference_attribute_resolves_against_its_own_file(hdf5_reference_p
     # Because the references point to differently-named targets, correctly resolving
     # each against its own file yields "/target_alpha" vs "/target_beta" -- a difference.
     assert "my_ref" in comparison.num_attribute_diffs["difference_types"]
+
+
+@pytest.mark.parametrize("text", ["NASA", "café", "", "b'NASA'"])
+def test_variable_string_storage_types_compare_equal(tmp_path, text):
+    """Fixed-width bytes and variable-width UTF-8 denote the same attribute text."""
+    paths = [tmp_path / "fixed.h5", tmp_path / "variable.h5"]
+    values = [np.bytes_(text.encode("utf-8")), text]
+    for path, value in zip(paths, values, strict=True):
+        with h5py.File(path, "w") as dataset:
+            dataset.create_dataset("data", data=np.arange(3)).attrs["source"] = value
+
+    report = tmp_path / "report.txt"
+    assert compare(*paths, show_attributes=True, file_text=str(report)) == 0
+    assert text in report.read_text()
+
+
+@pytest.mark.parametrize("shape", [(2,), (1, 2), (2, 1), (1, 1, 2), (0,)])
+def test_variable_string_array_storage_types_compare_equal(tmp_path, shape):
+    """String arrays must not be interpreted as HDF5 object references."""
+    paths = [tmp_path / "fixed.h5", tmp_path / "variable.h5"]
+    count = int(np.prod(shape))
+    values = ["NASA", "café"][:count]
+    fixed = np.array([value.encode("utf-8") for value in values], dtype="S8").reshape(shape)
+    variable = np.array(values, dtype=h5py.string_dtype()).reshape(shape)
+    for path, value in zip(paths, [fixed, variable], strict=True):
+        with h5py.File(path, "w") as dataset:
+            dataset.create_dataset("data", data=np.arange(3)).attrs["source"] = value
+
+    assert compare(*paths, show_attributes=True) == 0
+
+
+def test_invalid_variable_string_bytes_use_replacement_decoding(tmp_path):
+    """Use the same invalid-UTF-8 policy as the root attribute normalizer."""
+    path = tmp_path / "invalid.h5"
+    with h5py.File(path, "w") as dataset:
+        variable = dataset.create_dataset("data", data=np.arange(3))
+        variable.attrs["source"] = np.bytes_(b"NASA\xff")
+        variable.attrs["sources"] = np.array([b"NASA\xff"], dtype="S5")
+
+    report = tmp_path / "report.txt"
+    assert compare(path, path, show_attributes=True, file_text=str(report)) == 0
+    assert "NASA�" in report.read_text()
+    assert "\\xff" not in report.read_text()
+
+
+def test_hdf5_numeric_attribute_array_format_is_unchanged(tmp_path):
+    """Text decoding must not change the existing numeric array representation."""
+    path = tmp_path / "numeric.h5"
+    value = np.array([1, 2, 3, 4])
+    with h5py.File(path, "w") as dataset:
+        dataset.create_dataset("data", data=np.arange(3)).attrs["matrix"] = value
+    file = FileToCompare(path=path, type="hdf5")
+    with Outputter() as out, h5py.File(path) as dataset:
+        comparison = Comparison(file, file, out, show_chunks=False, show_attributes=True)
+        props = comparison._create_var_properties(dataset, "data", dataset)
+        assert props.attributes["matrix"] == str(value)
+
+
+@pytest.mark.parametrize("array", [False, True])
+def test_different_variable_strings_are_still_reported(tmp_path, array):
+    """Decoding storage types must preserve genuine text differences."""
+    paths = [tmp_path / "a.h5", tmp_path / "b.h5"]
+    for path, value in zip(paths, ["NASA", "GSFC"], strict=True):
+        stored = np.bytes_(value.encode("utf-8"))
+        if array:
+            stored = np.array([stored])
+        with h5py.File(path, "w") as dataset:
+            dataset.create_dataset("data", data=np.arange(3)).attrs["source"] = stored
+    assert compare(*paths, show_attributes=True) > 0


### PR DESCRIPTION
Fixes #370.

Decode HDF5 scalar attribute bytes through the shared normalizer and decode string arrays before reference handling. Fixed- and variable-length storage now compare as the same text, including multidimensional arrays, while numeric arrays and object-reference resolution retain their existing behavior.

Validation on macOS arm64, Python 3.12.11:
- Full offline suite: 68 passed, 1 authenticated integration test deselected, including 13 new cases. Ten new cases failed before the fix.
- Existing NetCDF text/CSV/Excel golden checks passed unchanged.
- The observed ATL06 fixture total remains 4,978; no expected-count or fixture changes were needed.
- Ruff, formatting, and `git diff --check` passed. Changelog updated.

Live Earthdata downloads and Windows/Linux runs were not performed. The separate list-truncation issue #371 is outside this change.


<!-- readthedocs-preview ncompare start -->
----
📚 Documentation preview 📚: https://ncompare--372.org.readthedocs.build/en/372/

<!-- readthedocs-preview ncompare end -->