### PR TITLE
Fix misleading attribute truncation and hidden tail differences

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Compare complete attribute values before shortening report lists, so differences after the fifth element remain detectable. Only append an ellipsis when list items are actually omitted ([#371](https://github.com/nasa/ncompare/issues/371)).
+
 - Fix the command line failing on netCDF files on Linux with "[Errno -101] NetCDF: HDF error". `h5py` and `netCDF4` each bundle their own copy of the HDF5 library and only the first loaded is used, so `netCDF4` is now imported first ([#363](https://github.com/nasa/ncompare/issues/363)) ([**@danielfromearth**](https://github.com/danielfromearth))
 - Resolve each variable's HDF5 object-reference attributes against its own file (File B was incorrectly dereferenced against File A), and use the correct parent-group name when building nested group paths during traversal ([#341](https://github.com/nasa/ncompare/issues/341)) ([**@danielfromearth**](https://github.com/danielfromearth))
 - Restore colorama's global color state after a no-color comparison, so `no_color=True` no longer permanently disables color for later comparisons or other libraries in the same process ([#345](https://github.com/nasa/ncompare/issues/345)) ([**@danielfromearth**](https://github.com/danielfromearth))

--- a/ncompare/Comparison.py
+++ b/ncompare/Comparison.py
@@ -33,8 +33,10 @@ import numpy as np
 from colorama import Fore
 
 from ncompare.getters import (
+    _value_to_comparable_str,
     get_and_check_variable_attributes,
     get_and_check_variable_scale_factor,
+    get_attribute_value_as_str,
     get_root_attributes,
     get_root_dims,
     get_root_groups,
@@ -238,7 +240,9 @@ class Comparison:
         # Compute these once and reuse them below -- both when deciding whether to
         # highlight the variable header and when printing each attribute row.
         variable_attribute_pairs = (
-            list(get_and_check_variable_attributes(v_a, v_b)) if self.show_attributes else []
+            list(get_and_check_variable_attributes(v_a, v_b, max_items=None))
+            if self.show_attributes
+            else []
         )
         scale_factor_pair = get_and_check_variable_scale_factor(v_a, v_b)
 
@@ -290,10 +294,22 @@ class Comparison:
         for attr_a_key, attr_a, attr_b_key, attr_b in variable_attribute_pairs:
             # attr_a_key may be empty if the variable doesn't exist in File A.
             attribute_key = attr_a_key if attr_a_key else attr_b_key
-            self._tally_attribute_difference(attribute_key, attr_a, attr_b)
+            self._tally_attribute_difference(
+                attribute_key,
+                attr_a,
+                attr_b,
+                display_values=(
+                    get_attribute_value_as_str(v_a, attr_a_key),
+                    get_attribute_value_as_str(v_b, attr_b_key),
+                ),
+            )
 
     def _tally_attribute_difference(
-        self, attribute_name: str, attribute_a: str, attribute_b: str
+        self,
+        attribute_name: str,
+        attribute_a: str,
+        attribute_b: str,
+        display_values: tuple[str, str] | None = None,
     ) -> None:
         """Print one attribute row side by side and fold it into the attribute tally.
 
@@ -305,13 +321,19 @@ class Comparison:
             the attribute's value in File A, already stringified
         attribute_b
             the attribute's value in File B, already stringified
+        display_values
+            Optional shortened values for the report, separate from comparison.
 
         Returns
         -------
         None
         """
         diff_condition: SummaryDifferenceKeys = self.out.side_by_side(
-            f"{attribute_name}:", attribute_a, attribute_b, highlight_diff=True
+            f"{attribute_name}:",
+            attribute_a,
+            attribute_b,
+            highlight_diff=True,
+            display_values=display_values,
         )
         self.num_attribute_diffs[diff_condition] += 1
         if diff_condition in ("left", "right", "both"):
@@ -343,16 +365,20 @@ class Comparison:
         None
         """
         self.out.print(Fore.LIGHTBLUE_EX + "\nRoot-level Attributes:", add_to_history=True)
-        attrs_a = get_root_attributes(self.file1)
-        attrs_b = get_root_attributes(self.file2)
+        attrs_a = get_root_attributes(self.file1, stringify=False)
+        attrs_b = get_root_attributes(self.file2, stringify=False)
 
         for _, attr_a_key, attr_b_key in common_elements(attrs_a.keys(), attrs_b.keys()):
             # attr_a_key is empty when the attribute exists only in File B.
             attribute_key = attr_a_key if attr_a_key else attr_b_key
             self._tally_attribute_difference(
                 attribute_key,
-                attrs_a.get(attr_a_key, ""),
-                attrs_b.get(attr_b_key, ""),
+                _value_to_comparable_str(attrs_a.get(attr_a_key, ""), max_items=None),
+                _value_to_comparable_str(attrs_b.get(attr_b_key, ""), max_items=None),
+                display_values=(
+                    _value_to_comparable_str(attrs_a.get(attr_a_key, "")),
+                    _value_to_comparable_str(attrs_b.get(attr_b_key, "")),
+                ),
             )
 
     def _print_summary(self):

--- a/ncompare/getters.py
+++ b/ncompare/getters.py
@@ -24,7 +24,7 @@ def get_and_check_variable_scale_factor(
 
 
 def get_and_check_variable_attributes(
-    v_a: VarProperties, v_b: VarProperties
+    v_a: VarProperties, v_b: VarProperties, *, max_items: int | None = 5
 ) -> Iterator[tuple[str, str, str, str]]:
     """Go through and yield each attribute pair for two variables."""
     # Get the name of attributes if they exist
@@ -36,12 +36,12 @@ def get_and_check_variable_attributes(
         attrs_b_names = v_b.attributes.keys()
     # Iterate and print each attribute
     for _, attr_a_key, attr_b_key in common_elements(attrs_a_names, attrs_b_names):
-        attr_a = get_attribute_value_as_str(v_a, attr_a_key)
-        attr_b = get_attribute_value_as_str(v_b, attr_b_key)
+        attr_a = get_attribute_value_as_str(v_a, attr_a_key, max_items=max_items)
+        attr_b = get_attribute_value_as_str(v_b, attr_b_key, max_items=max_items)
         yield attr_a_key, attr_a, attr_b_key, attr_b
 
 
-def _value_to_comparable_str(value: object) -> str:
+def _value_to_comparable_str(value: object, *, max_items: int | None = 5) -> str:
     """Render an attribute value as the string ncompare compares and displays.
 
     Byte strings are decoded first: ``h5py`` returns HDF5 fixed-length string
@@ -55,32 +55,34 @@ def _value_to_comparable_str(value: object) -> str:
     ----------
     value
         the raw attribute value, as returned by ``netCDF4`` or ``h5py``
+    max_items
+        Maximum iterable items to display; None retains every item for comparison.
 
     Returns
     -------
     str
-        the value as a string; a long iterable is truncated to five elements
+        the value as a string, with an ellipsis only when items were omitted
     """
     if isinstance(value, bytes):
         return value.decode("utf-8", errors="replace")
-    if isinstance(value, np.ndarray) and value.dtype.kind in ("S", "O"):
-        value = [
-            item.decode("utf-8", errors="replace") if isinstance(item, bytes) else item
-            for item in value.tolist()
-        ]
+    if isinstance(value, np.ndarray) and value.ndim == 0:
+        return _value_to_comparable_str(value.item(), max_items=max_items)
     if isinstance(value, Iterable) and not isinstance(value, (str, float)):
-        # TODO: by truncating a list (or other iterable) here,
-        #  we are preventing any subsequent difference checker from detecting
-        #  differences past the 5th element in the iterable.
-        #  So, we need to figure out a way to still check for other differences past the 5th element.
-        return "[" + ", ".join([str(x) for x in list(value)[:5]]) + ", ..." + "]"
+        items = list(value)
+        shown = items if max_items is None else items[:max_items]
+        text = ", ".join(_value_to_comparable_str(item, max_items=max_items) for item in shown)
+        if max_items is not None and len(items) > max_items:
+            text += ", ..."
+        return "[" + text + "]"
     return str(value)
 
 
-def get_attribute_value_as_str(varprops: VarProperties, attribute_key: str) -> str:
+def get_attribute_value_as_str(
+    varprops: VarProperties, attribute_key: str, *, max_items: int | None = 5
+) -> str:
     """Get a string representation of the attribute value."""
     if attribute_key and (attribute_key in varprops.attributes):
-        return _value_to_comparable_str(varprops.attributes[attribute_key])
+        return _value_to_comparable_str(varprops.attributes[attribute_key], max_items=max_items)
 
     return ""
 
@@ -96,33 +98,38 @@ def get_root_groups(file: FileToCompare) -> list:
     return groups_list
 
 
-def get_root_attributes(file: FileToCompare) -> dict:
+def get_root_attributes(file: FileToCompare, *, stringify: bool = True) -> dict:
     """Get the global (root-level) attributes of a netCDF or HDF5 file.
 
     Parameters
     ----------
     file
         the file whose root-level attributes are wanted
+    stringify
+        Render values for display by default. False returns the raw values so
+        callers can compare complete values and format them separately.
 
     Returns
     -------
     dict
-        attribute name -> value, each rendered with ``_value_to_comparable_str``;
-        an empty dict if the file's attributes cannot be read
+        attribute name -> value, rendered with ``_value_to_comparable_str`` unless
+        stringify is False; an empty dict if the file's attributes cannot be read
     """
     attributes: dict = {}
     try:
         if file.type == "netcdf":
             with netCDF4.Dataset(file.path, mode="r") as dataset:
                 for name in dataset.ncattrs():
-                    attributes[name] = _value_to_comparable_str(dataset.getncattr(name))
+                    attributes[name] = dataset.getncattr(name)
         elif file.type == "hdf5":
             with h5py.File(file.path, mode="r") as dataset:
                 for name in dataset.attrs.keys():
-                    attributes[name] = _value_to_comparable_str(dataset.attrs[name])
+                    attributes[name] = dataset.attrs[name]
     except (OSError, RuntimeError, KeyError):
         # Mirrors _get_hdf5_root_dims: some files can't be introspected; degrade gracefully.
         return {}
+    if stringify:
+        return {name: _value_to_comparable_str(value) for name, value in attributes.items()}
     return attributes
 
 

--- a/ncompare/printing.py
+++ b/ncompare/printing.py
@@ -248,6 +248,7 @@ class Outputter:
         highlight_diff=False,
         force_display_even_if_same=False,
         force_color=None,
+        display_values: tuple[str, str] | None = None,
     ) -> SummaryDifferenceKeys:
         """Print three strings on one line, with customized formatting and an optional marker in the fourth column.
 
@@ -260,6 +261,9 @@ class Outputter:
         highlight_diff
         force_display_even_if_same
         force_color
+        display_values
+            Optional shortened values to print instead of str_b and str_c.
+            Comparison, filtering, and classification still use the full values.
 
         Returns
         -------
@@ -270,6 +274,7 @@ class Outputter:
             "both" if they are different from each other.
         """
         are_different = str_b != str_c
+        has_left, has_right = bool(str_b), bool(str_c)
         if (
             (force_display_even_if_same is False)
             and (are_different is False)
@@ -293,6 +298,9 @@ class Outputter:
             extra_style_space = ""
             str_marker = ""
 
+        if display_values is not None:
+            str_b, str_c = display_values
+
         if dash_line:
             self.print(
                 f" {extra_style_space}"
@@ -314,9 +322,9 @@ class Outputter:
 
         if not are_different:
             return "shared"
-        elif str_b and (not str_c):
+        elif has_left and not has_right:
             return "left"  # there is only a non-empty string on the left side.
-        elif str_c and (not str_b):
+        elif has_right and not has_left:
             return "right"  # there is only a non-empty string on the right side.
         else:
             return "both"  # there are non-empty strings on both sides, and they are not equal.

--- a/tests/test_attribute_comparison.py
+++ b/tests/test_attribute_comparison.py
@@ -1,0 +1,140 @@
+# Copyright 2024 United States Government as represented by the Administrator of the
+# National Aeronautics and Space Administration. All Rights Reserved.
+#
+# This software calls the following third-party software,
+# which is subject to the terms and conditions of its licensor, as applicable.
+# Users must license their own copies; the links are provided for convenience only.
+#
+# colorama - BSD-3-Clause - https://opensource.org/licenses/BSD-3-Clause
+# netCDF4 - MIT License - https://opensource.org/licenses/MIT
+# numpy - BSD-3-Clause - https://opensource.org/licenses/BSD-3-Clause
+# openpyxl - MIT License - https://opensource.org/licenses/MIT
+# xarray - Apache License, version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
+# Python Standard Library - Python Software Foundation (PSF) License Agreement-
+#   https://docs.python.org/3/license.html#psf-license
+#
+# The ncompare: NetCDF structural comparison tool platform is licensed under the
+# Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+
+"""Regression coverage for complete attribute comparison and bounded display."""
+
+import h5py
+import netCDF4
+import numpy as np
+import pytest
+
+from ncompare.Comparison import Comparison
+from ncompare.getters import _value_to_comparable_str
+from ncompare.printing import Outputter
+from ncompare.utility_types import FileToCompare
+
+
+@pytest.mark.parametrize(
+    "values, expected",
+    [
+        ([], "[]"),
+        ([1, 2, 3], "[1, 2, 3]"),
+        ([1, 2, 3, 4, 5], "[1, 2, 3, 4, 5]"),
+        ([1, 2, 3, 4, 5, 6], "[1, 2, 3, 4, 5, ...]"),
+        (np.array([b"NASA", b"JPL"]), "[NASA, JPL]"),
+    ],
+)
+def test_ellipsis_means_items_were_omitted(values, expected):
+    assert _value_to_comparable_str(values) == expected
+
+
+@pytest.mark.parametrize(
+    "file_type, scope",
+    [
+        ("netcdf", "root"),
+        ("netcdf", "variable"),
+        ("hdf5", "root"),
+    ],
+)
+@pytest.mark.parametrize("other", [[0, 1, 2, 3, 4, 99], [0, 1, 2, 3, 4]])
+@pytest.mark.parametrize("keep_only_diffs", [False, True])
+def test_attribute_tail_differences_are_counted(tmp_path, file_type, scope, other, keep_only_diffs):
+    paths = [tmp_path / (name + (".nc" if file_type == "netcdf" else ".h5")) for name in ["a", "b"]]
+    for path, values in zip(paths, [[0, 1, 2, 3, 4, 5], other]):
+        if file_type == "netcdf":
+            with netCDF4.Dataset(path, "w") as dataset:
+                target = dataset if scope == "root" else dataset.createVariable("data", "f4", ())
+                target.setncattr("samples", values)
+        else:
+            with h5py.File(path, "w") as dataset:
+                dataset.attrs["samples"] = values
+    with Outputter(no_color=True, keep_only_diffs=keep_only_diffs, keep_print_history=True) as out:
+        comparison = Comparison(
+            *(FileToCompare(p, type=file_type) for p in paths),
+            out,
+            show_chunks=False,
+            show_attributes=True,
+        )
+        total = comparison.run_through_comparisons()
+        assert total > 0
+        assert comparison.num_attribute_diffs["both"] == 1
+        rows = [row for row in out._line_history if row[0] == "samples:"]
+        assert len(rows) == 1
+        assert rows[0][1] == "[0, 1, 2, 3, 4, ...]"
+        assert rows[0][2] == ("[0, 1, 2, 3, 4, ...]" if len(other) > 5 else "[0, 1, 2, 3, 4]")
+        assert rows[0][3]
+        if scope == "variable":
+            assert any(row[0] == "-----VARIABLE-----:" for row in out._line_history)
+
+
+def test_full_comparison_does_not_use_numpy_ellipsis():
+    values = np.arange(1200).reshape(1, 1200)
+    other = values.copy()
+    other[0, 600] = -1
+    assert _value_to_comparable_str(values, max_items=None) != _value_to_comparable_str(
+        other, max_items=None
+    )
+
+
+def test_display_override_does_not_change_classification():
+    with Outputter(no_color=True, keep_only_diffs=True, keep_print_history=True) as out:
+        assert (
+            out.side_by_side(
+                "value",
+                "abcdef",
+                "abcxyz",
+                highlight_diff=True,
+                display_values=("abc...", "abc..."),
+            )
+            == "both"
+        )
+        assert out._line_history[-1][1:3] == ["abc...", "abc..."]
+        assert out._line_history[-1][3]
+        assert out.side_by_side("left", "abcdef", "", display_values=("abc...", "")) == "left"
+        assert out.side_by_side("right", "", "abcdef", display_values=("", "abc...")) == "right"
+        before = len(out._line_history)
+        assert out.side_by_side("equal", "abcdef", "abcdef", display_values=("a", "b")) == "shared"
+        assert len(out._line_history) == before
+
+
+@pytest.mark.parametrize("value", ["abcdefghi", b"NASA", np.array(2), 1.25])
+def test_scalar_values_are_not_truncated(value):
+    assert _value_to_comparable_str(value) == _value_to_comparable_str(value, max_items=None)
+
+
+def test_equal_long_attributes_are_not_reported_as_different(tmp_path):
+    paths = [tmp_path / name for name in ("a.nc", "b.nc")]
+    for path in paths:
+        with netCDF4.Dataset(path, "w") as dataset:
+            dataset.setncattr("samples", np.arange(20))
+    with Outputter(no_color=True, keep_only_diffs=True, keep_print_history=True) as out:
+        comparison = Comparison(
+            *(FileToCompare(p, type="netcdf") for p in paths),
+            out,
+            show_chunks=False,
+            show_attributes=True,
+        )
+        assert comparison.run_through_comparisons() == 0
+        assert not any(row[0] == "samples:" for row in out._line_history)

--- a/tests/test_getters.py
+++ b/tests/test_getters.py
@@ -90,7 +90,7 @@ def test_get_root_attributes_hdf5_array_of_fixed_length_strings(tmp_path):
 
     result = get_root_attributes(FileToCompare(filepath, type="hdf5"))
 
-    assert result["sources"] == "[NASA, JPL, GSFC, ...]"
+    assert result["sources"] == "[NASA, JPL, GSFC]"
 
 
 def test_get_root_attributes_degrades_gracefully_on_unreadable_file(tmp_path):


### PR DESCRIPTION
Fixes #371.

Compare complete attribute values while keeping the existing five-item report preview. Add a separate display-value option to the outputter so shortening a row cannot change its classification, difference marker, or keep-only-differences filtering. Only append an ellipsis when items were omitted, and render nested arrays without NumPy's implicit comparison truncation.

### Validation

macOS arm64, Python 3.12.11:
- Full offline suite: 79 passed, including 24 new cases; one authenticated integration test deselected.
- End-to-end regressions reproduce differences at the sixth item and differences in length for NetCDF root/variable attributes and HDF5 root attributes, with both filtering modes. These failed before the fix.
- Empty, short, nested, scalar, and equal long values, output classification, and markers are covered.
- Existing text/CSV/Excel golden checks passed unchanged. The observed ATL06 fixture count remains 4,978, so no fixture or expected-count updates were needed.
- Ruff checks/formatting and `git diff --check` passed. Changelog updated.

Live Earthdata and Windows/Linux runs were not performed. The byte-decoding changes in #372 and palette isolation in #369 remain separate.


<!-- readthedocs-preview ncompare start -->
----
📚 Documentation preview 📚: https://ncompare--373.org.readthedocs.build/en/373/

<!-- readthedocs-preview ncompare end -->